### PR TITLE
Add Launchpad pad grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,39 +1,17 @@
-import { useState } from 'react';
 import { useMidi } from './useMidi';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
+import LaunchpadCanvas from './LaunchpadCanvas';
 import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0);
   const { inputs, outputs } = useMidi();
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
+    <div className="App">
       <p>
         Inputs: {inputs.length} Outputs: {outputs.length}
       </p>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      <LaunchpadCanvas />
+    </div>
   );
 }
 

--- a/src/LaunchpadCanvas.css
+++ b/src/LaunchpadCanvas.css
@@ -1,0 +1,15 @@
+.launchpad-grid {
+  display: grid;
+  grid-template-columns: repeat(10, 2rem);
+  grid-template-rows: repeat(10, 2rem);
+  gap: 0.25rem;
+  justify-content: center;
+}
+
+.pad {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+}

--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -1,0 +1,91 @@
+import React, { memo } from 'react';
+import { noteOn, cc } from './midiMessages';
+import { useMidi } from './useMidi';
+import { useStore } from './store';
+import './LaunchpadCanvas.css';
+
+// MIDI mappings for Launchpad X
+const NOTE_GRID: number[][] = [
+  [81, 82, 83, 84, 85, 86, 87, 88],
+  [71, 72, 73, 74, 75, 76, 77, 78],
+  [61, 62, 63, 64, 65, 66, 67, 68],
+  [51, 52, 53, 54, 55, 56, 57, 58],
+  [41, 42, 43, 44, 45, 46, 47, 48],
+  [31, 32, 33, 34, 35, 36, 37, 38],
+  [21, 22, 23, 24, 25, 26, 27, 28],
+  [11, 12, 13, 14, 15, 16, 17, 18],
+];
+
+const TOP_CC = [104, 105, 106, 107, 108, 109, 110, 111];
+const SIDE_CC = [91, 92, 93, 94, 95, 96, 97, 98];
+
+function hexToVelocity(hex: string) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return Math.round(((r + g + b) / (255 * 3)) * 127);
+}
+
+interface PadProps {
+  id: string;
+  note?: number;
+  cc?: number;
+}
+
+const Pad = memo(({ id, note, cc: ccNum }: PadProps) => {
+  const colour = useStore((s) => s.padColours[id] || '#000000');
+  const setPadColour = useStore((s) => s.setPadColour);
+  const { send } = useMidi();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setPadColour(id, value);
+    const vel = hexToVelocity(value);
+    if (note !== undefined) send(noteOn(note, vel));
+    else if (ccNum !== undefined) send(cc(ccNum, vel));
+  };
+
+  return (
+    <input
+      type="color"
+      className="pad"
+      value={colour}
+      onChange={handleChange}
+    />
+  );
+});
+
+export function LaunchpadCanvas() {
+  const grid: React.ReactElement[] = [];
+
+  // top-left corner
+  grid.push(<div key="tl" />);
+
+  // top row
+  for (let x = 0; x < 8; x++) {
+    const id = `cc-${TOP_CC[x]}`;
+    grid.push(<Pad key={id} id={id} cc={TOP_CC[x]} />);
+  }
+
+  // top-right corner
+  grid.push(<div key="tr" />);
+
+  for (let y = 0; y < 8; y++) {
+    // left blank column
+    grid.push(<div key={`l-${y}`} />);
+    for (let x = 0; x < 8; x++) {
+      const note = NOTE_GRID[y][x];
+      const id = `n-${note}`;
+      grid.push(<Pad key={id} id={id} note={note} />);
+    }
+    const id = `cc-${SIDE_CC[y]}`;
+    grid.push(<Pad key={id} id={id} cc={SIDE_CC[y]} />);
+  }
+
+  // bottom-right corner
+  grid.push(<div key="br" />);
+
+  return <div className="launchpad-grid">{grid}</div>;
+}
+
+export default memo(LaunchpadCanvas);

--- a/src/store.ts
+++ b/src/store.ts
@@ -34,7 +34,12 @@ interface MacrosSlice {
   removeMacro: (id: string) => void;
 }
 
-type StoreState = DevicesSlice & MacrosSlice;
+interface PadsSlice {
+  padColours: Record<string, string>;
+  setPadColour: (id: string, colour: string) => void;
+}
+
+type StoreState = DevicesSlice & MacrosSlice & PadsSlice;
 
 const kvStore = createIdbStore('automidi-db', 'state');
 
@@ -61,6 +66,9 @@ export const useStore = create<StoreState>()(
         })),
       removeMacro: (id) =>
         set((state) => ({ macros: state.macros.filter((m) => m.id !== id) })),
+      padColours: {},
+      setPadColour: (id, colour) =>
+        set((state) => ({ padColours: { ...state.padColours, [id]: colour } })),
     }),
     {
       name: 'store',


### PR DESCRIPTION
## Summary
- add LaunchpadCanvas pad grid component
- track pad colours in store
- style LaunchpadCanvas grid
- show the pad grid in App

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a6f8b68c883259becd9a34695ece6