### PR TITLE
Add macro list and editor UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useMidi } from './useMidi';
 import LaunchpadCanvas from './LaunchpadCanvas';
+import MacroList from './MacroList';
 import './App.css';
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
         Inputs: {inputs.length} Outputs: {outputs.length}
       </p>
       <LaunchpadCanvas />
+      <MacroList />
     </div>
   );
 }

--- a/src/MacroEditor.css
+++ b/src/MacroEditor.css
@@ -1,0 +1,39 @@
+.macro-editor {
+  padding: 1rem;
+  border: 1px solid #555;
+  margin-top: 1rem;
+}
+
+.timeline {
+  position: relative;
+  height: 80px;
+  border: 1px solid #888;
+  margin-bottom: 1rem;
+}
+
+.event {
+  position: absolute;
+  top: 20px;
+  height: 40px;
+  background: #646cff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: move;
+}
+
+.event .handle {
+  width: 6px;
+  background: #000;
+  cursor: ew-resize;
+  margin-left: 4px;
+}
+
+.json-editor {
+  width: 100%;
+  font-family: monospace;
+}
+
+.actions {
+  margin-top: 1rem;
+}

--- a/src/MacroEditor.tsx
+++ b/src/MacroEditor.tsx
@@ -1,0 +1,119 @@
+import { useRef, useState } from 'react';
+import type { Macro, MidiMsg } from './store';
+import './MacroEditor.css';
+
+interface Props {
+  macro: Macro;
+  onSave: (m: Macro) => void;
+  onCancel: () => void;
+}
+
+const SCALE = 0.2; // pixels per ms
+
+export default function MacroEditor({ macro, onSave, onCancel }: Props) {
+  const [name, setName] = useState(macro.name);
+  const [messages, setMessages] = useState<MidiMsg[]>(macro.messages);
+  const [tab, setTab] = useState<'timeline' | 'json'>('timeline');
+  const [json, setJson] = useState(() => JSON.stringify(messages, null, 2));
+  const dragIndex = useRef<number | null>(null);
+
+  const handleDrop = (idx: number) => {
+    if (dragIndex.current === null || dragIndex.current === idx) return;
+    setMessages((msgs) => {
+      const copy = [...msgs];
+      const [m] = copy.splice(dragIndex.current!, 1);
+      copy.splice(idx, 0, m);
+      return copy;
+    });
+    dragIndex.current = null;
+  };
+
+  const handleStretch = (i: number, diff: number) => {
+    setMessages((msgs) => {
+      const copy = [...msgs];
+      const ts = Math.max(1, copy[i].ts + diff / SCALE);
+      copy[i] = { ...copy[i], ts };
+      return copy;
+    });
+  };
+
+  const handleJsonBlur = () => {
+    try {
+      const arr: MidiMsg[] = JSON.parse(json);
+      setMessages(arr);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const save = () => {
+    onSave({ ...macro, name, messages });
+  };
+
+  let offset = 0;
+  const items = messages.map((m, i) => {
+    const left = offset;
+    offset += m.ts;
+    return { left, width: m.ts, msg: m, index: i };
+  });
+
+  return (
+    <div className="macro-editor">
+      <h3>Edit Macro</h3>
+      <input value={name} onChange={(e) => setName(e.target.value)} />
+      <div>
+        <button onClick={() => setTab('timeline')}>Timeline</button>
+        <button onClick={() => setTab('json')}>JSON</button>
+      </div>
+      {tab === 'timeline' ? (
+        <div className="timeline" onDragOver={(e) => e.preventDefault()}>
+          {items.map((item) => (
+            <div
+              key={item.index}
+              className="event"
+              draggable
+              onDragStart={() => {
+                dragIndex.current = item.index;
+              }}
+              onDrop={() => handleDrop(item.index)}
+              style={{
+                left: item.left * SCALE,
+                width: Math.max(10, item.width * SCALE),
+              }}
+            >
+              <span>{item.index + 1}</span>
+              <div
+                className="handle"
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  const startX = e.clientX;
+                  const move = (ev: MouseEvent) => {
+                    handleStretch(item.index, ev.clientX - startX);
+                  };
+                  const up = () => {
+                    window.removeEventListener('mousemove', move);
+                    window.removeEventListener('mouseup', up);
+                  };
+                  window.addEventListener('mousemove', move);
+                  window.addEventListener('mouseup', up);
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <textarea
+          className="json-editor"
+          value={json}
+          onChange={(e) => setJson(e.target.value)}
+          onBlur={handleJsonBlur}
+          rows={10}
+        />
+      )}
+      <div className="actions">
+        <button onClick={save}>Save</button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import MacroEditor from './MacroEditor';
+import { useMacroPlayer } from './useMacroPlayer';
+import { useStore, type Macro } from './store';
+
+export default function MacroList() {
+  const macros = useStore((s) => s.macros);
+  const removeMacro = useStore((s) => s.removeMacro);
+  const updateMacro = useStore((s) => s.updateMacro);
+  const { playMacro } = useMacroPlayer();
+  const [editing, setEditing] = useState<Macro | null>(null);
+
+  const handleSave = (macro: Macro) => {
+    updateMacro(macro);
+    setEditing(null);
+  };
+
+  return (
+    <div>
+      <h2>Macros</h2>
+      <ul>
+        {macros.map((m) => (
+          <li key={m.id}>
+            {m.name}
+            <button onClick={() => playMacro(m.id)}>Play</button>
+            <button onClick={() => playMacro(m.id, { loop: true })}>
+              Loop
+            </button>
+            <button onClick={() => setEditing(m)}>Edit</button>
+            <button onClick={() => removeMacro(m.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      {editing && (
+        <MacroEditor
+          macro={editing}
+          onSave={handleSave}
+          onCancel={() => setEditing(null)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `MacroList` with play, loop, edit and delete actions
- create `MacroEditor` with piano-roll style timeline and JSON editor
- integrate new components in `App`
- basic styling for the macro editor

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a728a16c883258d1d7004a14451a3