### PR TITLE
Add basic MIDI REST server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@tonejs/midi": "^2.0.28",
@@ -19,7 +20,9 @@
     "vite-plugin-pwa": "^1.0.1",
     "vite-plugin-svgr": "^4.3.0",
     "webmidi": "^3.1.12",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "express": "^4.21.2",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/readme.md
+++ b/readme.md
@@ -8,3 +8,4 @@ A Vite + React application for controlling MIDI devices. It auto-detects Launchp
 - `npm run build` – build for production
 - `npm run lint` – run ESLint
 - `npm run format` – run Prettier
+- `npm run server` – start the MIDI REST server

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,52 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import { WebMidi } from 'webmidi';
+
+const app = express();
+app.use(express.json());
+
+await WebMidi.enable();
+
+function listDevices() {
+  const inputs = WebMidi.inputs.map((input, index) => ({ id: index, name: input.name }));
+  const outputs = WebMidi.outputs.map((output, index) => ({ id: index, name: output.name }));
+  return { inputs, outputs };
+}
+
+app.get('/midi/devices', (_req, res) => {
+  res.json(listDevices());
+});
+
+app.post('/midi/send', (req, res) => {
+  const { port = 0, data } = req.body || {};
+  if (!Array.isArray(data)) {
+    res.status(400).json({ error: 'data must be an array of numbers' });
+    return;
+  }
+  const out = WebMidi.outputs[port];
+  if (!out) {
+    res.status(404).json({ error: `output port ${port} not found` });
+    return;
+  }
+  try {
+    out.send(data);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const server = app.listen(process.env.PORT || 3000, () => {
+  console.log(`Server listening on port ${server.address().port}`);
+});
+
+const wss = new WebSocketServer({ server });
+WebMidi.addListener('midimessage', e => {
+  const payload = JSON.stringify({ message: e.message.rawData, time: e.timestamp });
+  for (const ws of wss.clients) {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(payload);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add an Express-based MIDI server using WebMidi and WS
- expose `/midi/devices` and `/midi/send` routes
- send incoming MIDI messages over WebSocket
- document `npm run server`
- include new dependencies for server

## Testing
- `node --check server/index.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: build error for midi due to missing system deps)*

------
https://chatgpt.com/codex/tasks/task_e_686a76a37d6083258a6e4dfef282705e