### PR TITLE
Add MIDI device list to UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,13 @@
-import { useMidi } from './useMidi';
 import LaunchpadCanvas from './LaunchpadCanvas';
 import MacroList from './MacroList';
-import './App.css';
 import SysexWorkbench from './SysexWorkbench';
+import MidiDevices from './MidiDevices';
+import './App.css';
 
 function App() {
-  const { inputs, outputs } = useMidi();
-
   return (
     <div className="App">
-      <p>
-        Inputs: {inputs.length} Outputs: {outputs.length}
-      </p>
+      <MidiDevices />
       <LaunchpadCanvas />
       <MacroList />
       <SysexWorkbench />

--- a/src/MidiDevices.css
+++ b/src/MidiDevices.css
@@ -1,0 +1,14 @@
+.midi-devices {
+  margin-bottom: 1rem;
+}
+
+.device-lists {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.device-lists ul {
+  list-style: none;
+  padding: 0;
+}

--- a/src/MidiDevices.tsx
+++ b/src/MidiDevices.tsx
@@ -1,0 +1,30 @@
+import { useMidi } from './useMidi';
+import './MidiDevices.css';
+
+export default function MidiDevices() {
+  const { inputs, outputs } = useMidi();
+
+  return (
+    <div className="midi-devices">
+      <h2>MIDI Devices</h2>
+      <div className="device-lists">
+        <div>
+          <h3>Inputs</h3>
+          <ul>
+            {inputs.map((input) => (
+              <li key={input.id || input.name}>{input.name ?? input.id}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3>Outputs</h3>
+          <ul>
+            {outputs.map((output) => (
+              <li key={output.id || output.name}>{output.name ?? output.id}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a realtime list of MIDI inputs and outputs
- wire up new `MidiDevices` component in the app

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a780bf32c832590780e20cf4219f7