### PR TITLE
Refactor MIDI hook to use server

### DIFF
--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -1,47 +1,90 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+export interface MidiDevice {
+  id: number;
+  name: string;
+}
+
+export interface MidiMessage {
+  data: Uint8Array;
+  timestamp: number;
+}
+
 export function useMidi() {
-  const [inputs, setInputs] = useState<MIDIInput[]>([]);
-  const [outputs, setOutputs] = useState<MIDIOutput[]>([]);
-  const launchpad = useRef<MIDIOutput | null>(null);
-  const readyRef = useRef(false);
+  const [inputs, setInputs] = useState<MidiDevice[]>([]);
+  const [outputs, setOutputs] = useState<MidiDevice[]>([]);
+  const launchpad = useRef<number | null>(null);
+  const listeners = useRef(new Set<(msg: MidiMessage) => void>());
+  const wsRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
-    navigator.requestMIDIAccess({ sysex: true }).then((access) => {
-      const update = () => {
-        const inList = Array.from(access.inputs.values());
-        const outList = Array.from(access.outputs.values());
-        setInputs(inList);
-        setOutputs(outList);
-        const hasLaunchpad =
-          inList.some((i) => i.name?.includes('Launchpad X')) &&
-          outList.some((o) => o.name?.includes('Launchpad X'));
-        if (hasLaunchpad && !readyRef.current) {
-          readyRef.current = true;
-          window.dispatchEvent(new Event('midi-ready'));
-        }
-      };
-      access.onstatechange = update;
-      update();
-    });
+    let cancelled = false;
+
+    const update = () => {
+      fetch('/midi/devices')
+        .then((res) => res.json())
+        .then((data) => {
+          if (cancelled) return;
+          setInputs(data.inputs);
+          setOutputs(data.outputs);
+          const lp = data.outputs.find((o: MidiDevice) =>
+            o.name.includes('Launchpad X'),
+          );
+          launchpad.current = lp ? lp.id : null;
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    };
+
+    update();
+    const id = setInterval(update, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  useEffect(() => {
+    const ws = new WebSocket(`ws://${location.hostname}:3000`);
+    wsRef.current = ws;
+    ws.onmessage = (ev) => {
+      try {
+        const payload = JSON.parse(ev.data);
+        const msg: MidiMessage = {
+          data: new Uint8Array(payload.message),
+          timestamp: payload.time,
+        };
+        for (const fn of listeners.current) fn(msg);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    return () => {
+      ws.close();
+    };
   }, []);
 
   const send = useCallback(
-    (bytes: number[] | Uint8Array, output?: MIDIOutput | null) => {
-      const out = output ?? launchpad.current;
-      out?.send(bytes);
+    (bytes: number[] | Uint8Array, output?: MidiDevice | null) => {
+      const port = output?.id ?? launchpad.current ?? 0;
+      fetch('/midi/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ port, data: Array.from(bytes) }),
+      }).catch((err) => {
+        console.error(err);
+      });
     },
     [],
   );
 
-  const listen = useCallback(
-    (handler: (e: MIDIMessageEvent) => void, input?: MIDIInput) => {
-      const inp = input ?? inputs.find((i) => i.name?.includes('Launchpad X'));
-      inp?.addEventListener('midimessage', handler);
-      return () => inp?.removeEventListener('midimessage', handler);
-    },
-    [inputs],
-  );
+  const listen = useCallback((handler: (msg: MidiMessage) => void) => {
+    listeners.current.add(handler);
+    return () => {
+      listeners.current.delete(handler);
+    };
+  }, []);
 
   const enterProgrammer = useCallback(() => {
     send([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x01, 0xf7]);
@@ -52,13 +95,9 @@ export function useMidi() {
   }, [send]);
 
   useEffect(() => {
-    const handler = () => {
-      launchpad.current =
-        outputs.find((o) => o.name?.includes('Launchpad X')) ?? null;
+    if (launchpad.current !== null) {
       enterProgrammer();
-    };
-    window.addEventListener('midi-ready', handler);
-    return () => window.removeEventListener('midi-ready', handler);
+    }
   }, [outputs, enterProgrammer]);
 
   return {

--- a/src/useRecorder.ts
+++ b/src/useRecorder.ts
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useMidi } from './useMidi';
+import { useMidi, type MidiMessage } from './useMidi';
 import type { MidiMsg } from './store';
-import { useStore } from './store';
 
 export function useRecorder(isRecording: boolean) {
-  const { inputs, listen } = useMidi();
-  const inputId = useStore((s) => s.devices.inputId);
+  const { listen } = useMidi();
 
   const [messages, setMessages] = useState<MidiMsg[]>([]);
   const lastTime = useRef<number | null>(null);
@@ -15,25 +13,21 @@ export function useRecorder(isRecording: boolean) {
       lastTime.current = null;
       return;
     }
-    const input = inputs.find(
-      (i) => i.id === inputId && i.name?.includes('Launchpad X'),
-    );
-    if (!input) return;
-    const handler = (e: MIDIMessageEvent) => {
-      if (!e.data) return;
+    const handler = (msg: MidiMessage) => {
+      const { data } = msg;
       const now = performance.now();
       const prev = lastTime.current ?? now;
       lastTime.current = now;
       const delta = now - prev;
-      const bytes = Array.from(e.data);
+      const bytes = Array.from(data);
       setMessages((msgs) => [...msgs, { ts: delta, bytes }]);
     };
-    const unlisten = listen(handler, input);
+    const unlisten = listen(handler);
     return () => {
       unlisten();
       lastTime.current = null;
     };
-  }, [isRecording, inputId, inputs, listen]);
+  }, [isRecording, listen]);
 
   const clear = useCallback(() => {
     setMessages([]);


### PR DESCRIPTION
## Summary
- rework `useMidi` hook to talk to the Express/WS server
- expose new `MidiDevice` and `MidiMessage` types
- adapt recorder hook to new listener signature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a79998f48832592f0e73f5fab1654