### PR TITLE
Fix fetch error handling

### DIFF
--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -22,7 +22,14 @@ export function useMidi() {
 
     const update = () => {
       fetch('/midi/devices')
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(
+              `Failed to fetch MIDI devices: ${res.status} ${res.statusText}`,
+            );
+          }
+          return res.json();
+        })
         .then((data) => {
           if (cancelled) return;
           setInputs(data.inputs);


### PR DESCRIPTION
## Summary
- gracefully handle failure to fetch `/midi/devices`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a7b67e990832598885b23f7ee917d