### PR TITLE
Add manifest.webmanifest

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Automidi",
+  "short_name": "Automidi",
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,12 @@ import svgr from 'vite-plugin-svgr';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr(), VitePWA()],
+  plugins: [
+    react(),
+    svgr(),
+    VitePWA({
+      srcDir: 'public',
+      manifestFilename: 'manifest.webmanifest',
+    }),
+  ],
 });


### PR DESCRIPTION
## Summary
- add a basic PWA manifest in `public`
- configure VitePWA plugin to look in `public`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a80f1998c8325a63018503b0a4513