### PR TITLE
Switch MIDI client to sockets with settings modal

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -54,6 +54,15 @@ wss.on('connection', ws => {
       const data = JSON.parse(msg.toString());
       if (data.type === 'getDevices') {
         sendDevices(ws);
+      } else if (data.type === 'send') {
+        const { port = 0, bytes } = data;
+        const out = WebMidi.outputs[port];
+        if (!out || !Array.isArray(bytes)) return;
+        try {
+          out.send(bytes);
+        } catch (err) {
+          console.error(err);
+        }
       }
     } catch {
       // ignore malformed messages

--- a/src/ActionBar.css
+++ b/src/ActionBar.css
@@ -1,0 +1,18 @@
+.action-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.status.connected {
+  color: green;
+}
+
+.status.closed {
+  color: red;
+}
+
+.status.connecting {
+  color: orange;
+}

--- a/src/ActionBar.tsx
+++ b/src/ActionBar.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { useMidi } from './useMidi';
+import SettingsModal from './SettingsModal';
+import './ActionBar.css';
+
+export default function ActionBar() {
+  const { status } = useMidi();
+  const [showSettings, setShowSettings] = useState(false);
+
+  return (
+    <div className="action-bar">
+      <span className={`status ${status}`}>Socket: {status}</span>
+      <button onClick={() => setShowSettings(true)}>Settings</button>
+      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
+    </div>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import LaunchpadCanvas from './LaunchpadCanvas';
 import MacroList from './MacroList';
 import SysexWorkbench from './SysexWorkbench';
 import MidiDevices from './MidiDevices';
+import ActionBar from './ActionBar';
 import './App.css';
 
 function App() {
   return (
     <div className="App">
+      <ActionBar />
       <MidiDevices />
       <LaunchpadCanvas />
       <MacroList />

--- a/src/SettingsModal.css
+++ b/src/SettingsModal.css
@@ -1,0 +1,22 @@
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #888;
+}
+
+.modal-content label {
+  display: block;
+  margin-bottom: 0.5rem;
+}

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { useStore } from './store';
+import './SettingsModal.css';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function SettingsModal({ onClose }: Props) {
+  const host = useStore((s) => s.settings.host);
+  const port = useStore((s) => s.settings.port);
+  const setHost = useStore((s) => s.setHost);
+  const setPort = useStore((s) => s.setPort);
+
+  const [h, setH] = useState(host);
+  const [p, setP] = useState(port);
+
+  const save = () => {
+    setHost(h);
+    setPort(Number(p));
+    onClose();
+  };
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h3>Socket Settings</h3>
+        <label>
+          Host:
+          <input value={h} onChange={(e) => setH(e.target.value)} />
+        </label>
+        <label>
+          Port:
+          <input
+            type="number"
+            value={p}
+            onChange={(e) => setP(Number(e.target.value))}
+          />
+        </label>
+        <div className="actions">
+          <button onClick={save}>Save</button>
+          <button onClick={onClose}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,7 +39,16 @@ interface PadsSlice {
   setPadColour: (id: string, colour: string) => void;
 }
 
-type StoreState = DevicesSlice & MacrosSlice & PadsSlice;
+interface SettingsSlice {
+  settings: {
+    host: string;
+    port: number;
+  };
+  setHost: (h: string) => void;
+  setPort: (p: number) => void;
+}
+
+type StoreState = DevicesSlice & MacrosSlice & PadsSlice & SettingsSlice;
 
 const kvStore = createIdbStore('automidi-db', 'state');
 
@@ -69,6 +78,9 @@ export const useStore = create<StoreState>()(
       padColours: {},
       setPadColour: (id, colour) =>
         set((state) => ({ padColours: { ...state.padColours, [id]: colour } })),
+      settings: { host: location.hostname, port: 3000 },
+      setHost: (h) => set((state) => ({ settings: { ...state.settings, host: h } })),
+      setPort: (p) => set((state) => ({ settings: { ...state.settings, port: p } })),
     }),
     {
       name: 'store',


### PR DESCRIPTION
## Summary
- handle `send` messages over websocket on the node server
- store websocket host/port in Zustand store
- add socket connection status and allow configuring host/port
- insert `ActionBar` component with a settings modal
- communicate MIDI messages entirely via websocket

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a80d225c483259a9264b599266533