### PR TITLE
Add backend to dev workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently -k \"npm:server\" \"vite\"",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -29,6 +29,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
+    "concurrently": "^9.2.0",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/readme.md
+++ b/readme.md
@@ -36,9 +36,8 @@ to receive device updates and MIDI messages.
 ## Development workflow
 
 1. Install dependencies with `npm install`.
-2. Start the backend: `npm run server`.
-3. In another terminal start the Vite dev server: `npm run dev`.
-4. Visit <http://localhost:5173> and start playing with your MIDI gear.
+2. Start the development servers with `npm run dev`. This launches both the backend and Vite dev server concurrently.
+3. Visit <http://localhost:5173> and start playing with your MIDI gear.
 
 For a production build run `npm run build`. The output is placed in `dist/` and
 can be previewed locally using `npm run preview`.
@@ -71,9 +70,9 @@ testing device specific commands.
 
 ## Useful scripts
 
-- `npm run dev` – start the Vite dev server
+- `npm run dev` – start both the backend and Vite dev server
 - `npm run build` – build the React application for production
 - `npm run preview` – preview the production build locally
 - `npm run lint` – run ESLint
 - `npm run format` – run Prettier
-- `npm run server` – start the MIDI backend
+- `npm run server` – start only the MIDI backend


### PR DESCRIPTION
## Summary
- run Node backend alongside Vite dev server
- document updated workflow for starting both servers

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a85025ed083259949bdc96de83390