### PR TITLE
Integrate Cirrus UI and log MIDI sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/cirrus-ui/dist/cirrus.min.css"
+    />
+    <title>AutoMIDI</title>
   </head>
-  <body>
+  <body class="dark">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/server/index.js
+++ b/server/index.js
@@ -78,7 +78,13 @@ WebMidi.addListener('portschanged', () => {
 });
 
 WebMidi.addListener('midimessage', e => {
-  const payload = JSON.stringify({ type: 'midi', message: e.message.rawData, time: e.timestamp });
+  const source = e.port?.name ?? e.target?.name ?? 'unknown';
+  const payload = JSON.stringify({
+    type: 'midi',
+    message: e.message.rawData,
+    time: e.timestamp,
+    source,
+  });
   for (const ws of wss.clients) {
     if (ws.readyState === ws.OPEN) {
       ws.send(payload);

--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -9,6 +9,7 @@ export interface MidiDevice {
 export interface MidiMessage {
   data: Uint8Array;
   timestamp: number;
+  source?: string;
 }
 
 export function useMidi() {
@@ -45,7 +46,9 @@ export function useMidi() {
           const msg: MidiMessage = {
             data: new Uint8Array(payload.message),
             timestamp: payload.time,
+            source: payload.source,
           };
+          console.log('MIDI from', msg.source ?? 'unknown', msg.data);
           for (const fn of listeners.current) fn(msg);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- add Cirrus UI and dark theme
- log incoming MIDI source and message

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a88c17414832584d6ebadf20d664c