### PR TITLE
Fix sysex messages

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -7,7 +7,8 @@ app.use(express.json());
 
 let currentDevices = { inputs: [], outputs: [] };
 
-WebMidi.enable().then(() => {
+// Enable WebMidi with sysex support so we can send Launchpad commands
+WebMidi.enable({ sysex: true }).then(() => {
   console.log('WebMidi enabled successfully');
   
   function listDevices() {


### PR DESCRIPTION
## Summary
- enable sysex support when starting WebMidi in the MIDI server

## Testing
- `npm run lint` *(fails: 2 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686a9a73f8cc83258045c217f16eb2c5