### PR TITLE
Display MIDI log count in floating button

### DIFF
--- a/src/FloatingActionBar.tsx
+++ b/src/FloatingActionBar.tsx
@@ -1,9 +1,14 @@
 import { useState, useEffect } from 'react';
 import MidiLogger from './MidiLogger';
+import { useMidi } from './useMidi';
+import { useLogStore } from './logStore';
 
 export default function FloatingActionBar() {
   const [showLogger, setShowLogger] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const logCount = useLogStore((s) => s.logs.length);
+  const addMessage = useLogStore((s) => s.addMessage);
+  const { listen } = useMidi();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -14,15 +19,20 @@ export default function FloatingActionBar() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  useEffect(() => {
+    const unlisten = listen(addMessage);
+    return unlisten;
+  }, [listen, addMessage]);
+
   return (
     <>
       <div className={`floating-action-bar ${isScrolled ? 'scrolled' : ''}`}>
-        <button 
+        <button
           className="retro-button"
           onClick={() => setShowLogger(!showLogger)}
           title="Toggle MIDI Logger"
         >
-          {showLogger ? 'HIDE LOG' : 'MIDI LOG'}
+          {showLogger ? 'HIDE LOG' : 'MIDI LOG'} ({logCount})
         </button>
       </div>
       {showLogger && <MidiLogger onClose={() => setShowLogger(false)} />}

--- a/src/MidiLogger.tsx
+++ b/src/MidiLogger.tsx
@@ -1,41 +1,21 @@
 import { useEffect, useRef, useState } from 'react';
-import { useMidi, type MidiMessage } from './useMidi';
-
-interface LogEntry extends MidiMessage {
-  id: number;
-  formattedTime: string;
-}
+import { useLogStore } from './logStore';
 
 interface Props {
   onClose: () => void;
 }
 
 export default function MidiLogger({ onClose }: Props) {
-  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const logs = useLogStore((s) => s.logs);
+  const clearLogs = useLogStore((s) => s.clearLogs);
   const [filter, setFilter] = useState<'all' | 'in' | 'out'>('all');
-  const { listen } = useMidi();
   const logRef = useRef<HTMLDivElement>(null);
-  const idCounter = useRef(0);
-
-  useEffect(() => {
-    const unlisten = listen((msg: MidiMessage) => {
-      const entry: LogEntry = {
-        ...msg,
-        id: idCounter.current++,
-        formattedTime: new Date(msg.timestamp).toLocaleTimeString(),
-      };
-      setLogs(prev => [...prev.slice(-199), entry]); // Keep last 200 entries
-    });
-    return unlisten;
-  }, [listen]);
 
   useEffect(() => {
     if (logRef.current) {
       logRef.current.scrollTop = logRef.current.scrollHeight;
     }
   }, [logs]);
-
-  const clearLogs = () => setLogs([]);
 
   const formatBytes = (bytes: number[]) => {
     return bytes.map(b => b.toString(16).padStart(2, '0').toUpperCase()).join(' ');

--- a/src/logStore.ts
+++ b/src/logStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import type { MidiMessage } from './useMidi';
+
+export interface LogEntry extends MidiMessage {
+  id: number;
+  formattedTime: string;
+}
+
+interface LogStoreState {
+  logs: LogEntry[];
+  addMessage: (msg: MidiMessage) => void;
+  clearLogs: () => void;
+}
+
+let idCounter = 0;
+
+export const useLogStore = create<LogStoreState>((set) => ({
+  logs: [],
+  addMessage: (msg) => {
+    const entry: LogEntry = {
+      ...msg,
+      id: idCounter++,
+      formattedTime: new Date(msg.timestamp).toLocaleTimeString(),
+    };
+    set((state) => ({ logs: [...state.logs.slice(-199), entry] }));
+  },
+  clearLogs: () => set({ logs: [] }),
+}));


### PR DESCRIPTION
## Summary
- add Zustand store for MIDI log entries
- update MidiLogger to read logs from shared store
- capture MIDI messages in FloatingActionBar
- show log count in floating action bar button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS2307 Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686a9dc6144483258c4c82823ef44b63