### PR TITLE
Add settings modal button to floating bar

### DIFF
--- a/src/FloatingActionBar.tsx
+++ b/src/FloatingActionBar.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react';
 import MidiLogger from './MidiLogger';
+import SettingsModal from './SettingsModal';
 import { useMidi } from './useMidi';
 import { useLogStore } from './logStore';
 
 export default function FloatingActionBar() {
   const [showLogger, setShowLogger] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const logCount = useLogStore((s) => s.logs.length);
   const addMessage = useLogStore((s) => s.addMessage);
@@ -34,8 +36,16 @@ export default function FloatingActionBar() {
         >
           {showLogger ? 'HIDE LOG' : 'MIDI LOG'} ({logCount})
         </button>
+        <button
+          className="retro-button"
+          onClick={() => setShowSettings(true)}
+          title="Open Configuration"
+        >
+          CONFIG
+        </button>
       </div>
       {showLogger && <MidiLogger onClose={() => setShowLogger(false)} />}
+      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add configuration modal button to floating action bar

## Testing
- `npx prettier -w src/FloatingActionBar.tsx`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a9eef97a483258a883475c1f5b283