### PR TITLE
Add log limit setting and lightbox modal

### DIFF
--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useStore } from './store';
 
 interface Props {
@@ -10,27 +10,43 @@ export default function SettingsModal({ onClose }: Props) {
   const port = useStore((s) => s.settings.port);
   const autoReconnect = useStore((s) => s.settings.autoReconnect);
   const reconnectInterval = useStore((s) => s.settings.reconnectInterval);
+  const logLimit = useStore((s) => s.settings.logLimit);
   const setHost = useStore((s) => s.setHost);
   const setPort = useStore((s) => s.setPort);
   const setAutoReconnect = useStore((s) => s.setAutoReconnect);
   const setReconnectInterval = useStore((s) => s.setReconnectInterval);
+  const setLogLimit = useStore((s) => s.setLogLimit);
 
   const [h, setH] = useState(host);
   const [p, setP] = useState(port);
   const [ar, setAr] = useState(autoReconnect);
   const [ri, setRi] = useState(reconnectInterval / 1000); // Convert to seconds for UI
+  const [ll, setLl] = useState(logLimit);
 
   const save = () => {
     setHost(h);
     setPort(Number(p));
     setAutoReconnect(ar);
     setReconnectInterval(Math.max(1, ri) * 1000); // Minimum 1 second, convert back to milliseconds
+    setLogLimit(ll);
     onClose();
   };
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
   return (
-    <div className="modal d-block" style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}>
-      <div className="modal-dialog">
+    <div
+      className="modal d-block"
+      style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
+      onClick={onClose}
+    >
+      <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="modal-content modal-retro">
           <div className="modal-header">
             <h5 className="modal-title">◄ SYSTEM CONFIGURATION ►</h5>
@@ -57,6 +73,18 @@ export default function SettingsModal({ onClose }: Props) {
                 max="65535"
               />
               <small className="text-warning">Default: 3000</small>
+            </div>
+            <div className="mb-3">
+              <label className="form-label text-info">MAX LOG ENTRIES:</label>
+              <input
+                type="number"
+                className="form-control retro-input"
+                value={ll}
+                onChange={(e) => setLl(Number(e.target.value))}
+                min="1"
+                max="999"
+              />
+              <small className="text-warning">Default: 999</small>
             </div>
             <div className="mb-3">
               <div className="form-check">

--- a/src/logStore.ts
+++ b/src/logStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { MidiMessage } from './useMidi';
+import { useStore } from './store';
 
 export interface LogEntry extends MidiMessage {
   id: number;
@@ -22,7 +23,8 @@ export const useLogStore = create<LogStoreState>((set) => ({
       id: idCounter++,
       formattedTime: new Date(msg.timestamp).toLocaleTimeString(),
     };
-    set((state) => ({ logs: [...state.logs.slice(-199), entry] }));
+    const limit = useStore.getState().settings.logLimit || 999;
+    set((state) => ({ logs: [...state.logs.slice(-(limit - 1)), entry] }));
   },
   clearLogs: () => set({ logs: [] }),
 }));

--- a/src/store.ts
+++ b/src/store.ts
@@ -45,11 +45,13 @@ interface SettingsSlice {
     port: number;
     autoReconnect: boolean;
     reconnectInterval: number;
+    logLimit: number;
   };
   setHost: (h: string) => void;
   setPort: (p: number) => void;
   setAutoReconnect: (enabled: boolean) => void;
   setReconnectInterval: (interval: number) => void;
+  setLogLimit: (limit: number) => void;
 }
 
 type StoreState = DevicesSlice & MacrosSlice & PadsSlice & SettingsSlice;
@@ -82,20 +84,27 @@ export const useStore = create<StoreState>()(
       padColours: {},
       setPadColour: (id, colour) =>
         set((state) => ({ padColours: { ...state.padColours, [id]: colour } })),
-      settings: { 
-        host: location.hostname || 'localhost', 
+      settings: {
+        host: location.hostname || 'localhost',
         port: 3000,
         autoReconnect: true,
-        reconnectInterval: 2000
+        reconnectInterval: 2000,
+        logLimit: 999
       },
       setHost: (h) => set((state) => ({ settings: { ...state.settings, host: h } })),
       setPort: (p) => set((state) => ({ settings: { ...state.settings, port: p } })),
       setAutoReconnect: (enabled) => set((state) => ({ settings: { ...state.settings, autoReconnect: enabled } })),
-      setReconnectInterval: (interval) => set((state) => ({ 
-        settings: { 
-          ...state.settings, 
+      setReconnectInterval: (interval) => set((state) => ({
+        settings: {
+          ...state.settings,
           reconnectInterval: Math.max(1000, interval) // Minimum 1 second
-        } 
+        }
+      })),
+      setLogLimit: (limit) => set((state) => ({
+        settings: {
+          ...state.settings,
+          logLimit: Math.min(999, Math.max(1, limit))
+        }
       })),
     }),
     {


### PR DESCRIPTION
## Summary
- store log limit setting in Zustand store
- use configured log limit when saving MIDI log
- expose log limit in settings modal and support clicking outside to close

## Testing
- `npm run build` *(fails: Cannot find namespace 'NodeJS' and other TS errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686aa18235ac8325bbb11b5316fb53ae