### PR TITLE
UI ping improvements and modal fix

### DIFF
--- a/src/ActionBar.tsx
+++ b/src/ActionBar.tsx
@@ -10,8 +10,11 @@ export default function ActionBar() {
         <span className={`connection-status ${status} me-3`}>
           SOCKET: {status.toUpperCase()}
         </span>
-        <span className="text-info me-3">
-          PING: {pingDelay === null ? '---' : `${pingDelay}ms`}
+        <span className="text-info me-3 d-flex align-items-center">
+          PING:
+          <span className="ping-value ms-2">
+            {pingDelay === null ? '---' : `${pingDelay}ms`}
+          </span>
         </span>
         {launchpadDetected && (
           <span className="text-success me-3">

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useStore } from './store';
+import './SettingsModal.css';
 
 interface Props {
   onClose: () => void;

--- a/src/index.css
+++ b/src/index.css
@@ -268,6 +268,16 @@ body {
   border: 1px solid #ff0000;
 }
 
+/* Ping timing display */
+.ping-value {
+  display: inline-block;
+  padding: 4px 8px;
+  font-family: 'VT323', monospace;
+  background: #000040;
+  color: #00ffff;
+  border: 1px solid #00ffff;
+}
+
 @keyframes blink {
   0%, 50% { opacity: 1; }
   51%, 100% { opacity: 0.3; }

--- a/src/midiMessages.ts
+++ b/src/midiMessages.ts
@@ -82,8 +82,8 @@ export function clearAllLeds(): number[] {
 }
 
 export function scrollText(text: string, loop = false, speed = 7): number[] {
-  const textBytes = text.split('').map(c => c.charCodeAt(0));
-  return sysex(0x07, loop ? 0x01 : 0x00, clamp7(speed), 0x00, ...textBytes);
+  const textBytes = text.split('').map((c) => c.charCodeAt(0));
+  return sysex(0x07, loop ? 0x01 : 0x00, clamp7(speed), 0x00, ...textBytes, 0x00);
 }
 
 // Layout commands


### PR DESCRIPTION
## Summary
- show ping time inside a styled container
- load modal CSS so settings overlay is centered
- append string terminator for Launchpad scroll text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ab15eca3083258ad39f78bdbdae5d