### PR TITLE
Fix log button display and scrollText

### DIFF
--- a/src/FloatingActionBar.tsx
+++ b/src/FloatingActionBar.tsx
@@ -29,13 +29,15 @@ export default function FloatingActionBar() {
   return (
     <>
       <div className={`floating-action-bar ${isScrolled ? 'scrolled' : ''}`}>
-        <button
-          className="retro-button"
-          onClick={() => setShowLogger(!showLogger)}
-          title="Toggle MIDI Logger"
-        >
-          {showLogger ? 'HIDE LOG' : 'MIDI LOG'} ({logCount})
-        </button>
+        {!showLogger && (
+          <button
+            className="retro-button"
+            onClick={() => setShowLogger(true)}
+            title="Toggle MIDI Logger"
+          >
+            MIDI LOG ({logCount})
+          </button>
+        )}
         <button
           className="retro-button"
           onClick={() => setShowSettings(true)}

--- a/src/midiMessages.ts
+++ b/src/midiMessages.ts
@@ -82,7 +82,7 @@ export function clearAllLeds(): number[] {
 }
 
 export function scrollText(text: string, loop = false, speed = 7): number[] {
-  const textBytes = text.split('').map((c) => c.charCodeAt(0));
+  const textBytes = Array.from(text).map((c) => c.codePointAt(0) || 0);
   return sysex(0x07, loop ? 0x01 : 0x00, clamp7(speed), 0x00, ...textBytes, 0x00);
 }
 


### PR DESCRIPTION
## Summary
- hide MIDI log toggle when the log is open
- ensure scrollText handles unicode code points

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations and packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ac3d4c94c8325a1c53c48da49c170