### PR TITLE
Add MIDI log filters and ping configuration

### DIFF
--- a/src/ActionBar.tsx
+++ b/src/ActionBar.tsx
@@ -1,7 +1,17 @@
 import { useMidi } from './useMidi';
+import { useStore } from './store';
 
 export default function ActionBar() {
   const { status, reconnect, launchpadDetected, pingDelay } = useMidi();
+  const pingThresholds = useStore((s) => s.settings.pingThresholds);
+
+  const getPingClass = () => {
+    if (pingDelay === null) return 'blue';
+    if (pingDelay <= pingThresholds.green) return 'green';
+    if (pingDelay <= pingThresholds.yellow) return 'yellow';
+    if (pingDelay <= pingThresholds.orange) return 'orange';
+    return 'red';
+  };
 
   return (
     <div className="status-bar d-flex justify-content-between align-items-center">
@@ -12,20 +22,15 @@ export default function ActionBar() {
         </span>
         <span className="text-info me-3 d-flex align-items-center">
           PING:
-          <span className="ping-value ms-2">
+          <span className={`ping-value ms-2 ${getPingClass()}`}>
             {pingDelay === null ? '---' : `${pingDelay}ms`}
           </span>
         </span>
         {launchpadDetected && (
-          <span className="text-success me-3">
-            ► LAUNCHPAD X DETECTED
-          </span>
+          <span className="text-success me-3">► LAUNCHPAD X DETECTED</span>
         )}
         {status === 'closed' && (
-          <button 
-            className="retro-button btn-sm me-2"
-            onClick={reconnect}
-          >
+          <button className="retro-button btn-sm me-2" onClick={reconnect}>
             RECONNECT
           </button>
         )}

--- a/src/MidiLogger.tsx
+++ b/src/MidiLogger.tsx
@@ -9,6 +9,8 @@ export default function MidiLogger({ onClose }: Props) {
   const logs = useLogStore((s) => s.logs);
   const clearLogs = useLogStore((s) => s.clearLogs);
   const [filter, setFilter] = useState<'all' | 'in' | 'out'>('all');
+  const [typeFilter, setTypeFilter] = useState<string>('all');
+  const [deviceFilter, setDeviceFilter] = useState<string>('all');
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -18,56 +20,73 @@ export default function MidiLogger({ onClose }: Props) {
   }, [logs]);
 
   const formatBytes = (bytes: number[]) => {
-    return bytes.map(b => b.toString(16).padStart(2, '0').toUpperCase()).join(' ');
+    return bytes
+      .map((b) => b.toString(16).padStart(2, '0').toUpperCase())
+      .join(' ');
   };
 
   const getMsgType = (bytes: number[]) => {
     if (bytes.length === 0) return 'EMPTY';
     const status = bytes[0];
-    if (status >= 0x80 && status <= 0x8F) return 'NOTE_OFF';
-    if (status >= 0x90 && status <= 0x9F) return 'NOTE_ON';
-    if (status >= 0xA0 && status <= 0xAF) return 'AFTERTOUCH';
-    if (status >= 0xB0 && status <= 0xBF) return 'CC';
-    if (status >= 0xC0 && status <= 0xCF) return 'PROG_CHG';
-    if (status >= 0xD0 && status <= 0xDF) return 'CH_PRESSURE';
-    if (status >= 0xE0 && status <= 0xEF) return 'PITCH_BEND';
-    if (status === 0xF0) return 'SYSEX';
-    if (status === 0xF1) return 'MTC';
-    if (status === 0xF2) return 'SONG_POS';
-    if (status === 0xF3) return 'SONG_SEL';
-    if (status === 0xF6) return 'TUNE_REQ';
-    if (status === 0xF7) return 'EOX';
-    if (status === 0xF8) return 'CLOCK';
-    if (status === 0xFA) return 'START';
-    if (status === 0xFB) return 'CONTINUE';
-    if (status === 0xFC) return 'STOP';
-    if (status === 0xFE) return 'ACTIVE_SENSE';
-    if (status === 0xFF) return 'RESET';
+    if (status >= 0x80 && status <= 0x8f) return 'NOTE_OFF';
+    if (status >= 0x90 && status <= 0x9f) return 'NOTE_ON';
+    if (status >= 0xa0 && status <= 0xaf) return 'AFTERTOUCH';
+    if (status >= 0xb0 && status <= 0xbf) return 'CC';
+    if (status >= 0xc0 && status <= 0xcf) return 'PROG_CHG';
+    if (status >= 0xd0 && status <= 0xdf) return 'CH_PRESSURE';
+    if (status >= 0xe0 && status <= 0xef) return 'PITCH_BEND';
+    if (status === 0xf0) return 'SYSEX';
+    if (status === 0xf1) return 'MTC';
+    if (status === 0xf2) return 'SONG_POS';
+    if (status === 0xf3) return 'SONG_SEL';
+    if (status === 0xf6) return 'TUNE_REQ';
+    if (status === 0xf7) return 'EOX';
+    if (status === 0xf8) return 'CLOCK';
+    if (status === 0xfa) return 'START';
+    if (status === 0xfb) return 'CONTINUE';
+    if (status === 0xfc) return 'STOP';
+    if (status === 0xfe) return 'ACTIVE_SENSE';
+    if (status === 0xff) return 'RESET';
     return 'OTHER';
   };
 
   const getMessageDetails = (bytes: number[]) => {
     if (bytes.length === 0) return '';
     const status = bytes[0];
-    
-    if (status >= 0x90 && status <= 0x9F && bytes.length >= 3) {
-      return `Ch${(status & 0x0F) + 1} Note:${bytes[1]} Vel:${bytes[2]}`;
+
+    if (status >= 0x90 && status <= 0x9f && bytes.length >= 3) {
+      return `Ch${(status & 0x0f) + 1} Note:${bytes[1]} Vel:${bytes[2]}`;
     }
-    if (status >= 0x80 && status <= 0x8F && bytes.length >= 3) {
-      return `Ch${(status & 0x0F) + 1} Note:${bytes[1]} Vel:${bytes[2]}`;
+    if (status >= 0x80 && status <= 0x8f && bytes.length >= 3) {
+      return `Ch${(status & 0x0f) + 1} Note:${bytes[1]} Vel:${bytes[2]}`;
     }
-    if (status >= 0xB0 && status <= 0xBF && bytes.length >= 3) {
-      return `Ch${(status & 0x0F) + 1} CC:${bytes[1]} Val:${bytes[2]}`;
+    if (status >= 0xb0 && status <= 0xbf && bytes.length >= 3) {
+      return `Ch${(status & 0x0f) + 1} CC:${bytes[1]} Val:${bytes[2]}`;
     }
-    if (status === 0xF0) {
+    if (status === 0xf0) {
       return `Len:${bytes.length}`;
     }
     return '';
   };
 
-  const filteredLogs = logs.filter(log => {
-    if (filter === 'all') return true;
-    return log.direction === filter;
+  const messageTypes = Array.from(
+    new Set(logs.map((l) => getMsgType(l.message))),
+  );
+  const devices = Array.from(
+    new Set(
+      logs
+        .map((l) => (l.direction === 'in' ? l.source : l.target))
+        .filter((d): d is string => !!d),
+    ),
+  );
+
+  const filteredLogs = logs.filter((log) => {
+    if (filter !== 'all' && log.direction !== filter) return false;
+    const type = getMsgType(log.message);
+    if (typeFilter !== 'all' && type !== typeFilter) return false;
+    const device = log.direction === 'in' ? log.source : log.target;
+    if (deviceFilter !== 'all' && device !== deviceFilter) return false;
+    return true;
   });
 
   return (
@@ -75,15 +94,45 @@ export default function MidiLogger({ onClose }: Props) {
       <div className="logger-header">
         <h5 className="text-warning">◄ MIDI DATA STREAM ►</h5>
         <div className="d-flex align-items-center">
-          <select 
-            className="form-select retro-select me-2" 
+          <select
+            className="form-select retro-select me-2"
             style={{ width: 'auto', fontSize: '12px' }}
             value={filter}
             onChange={(e) => setFilter(e.target.value as 'all' | 'in' | 'out')}
           >
             <option value="all">ALL ({logs.length})</option>
-            <option value="in">IN ({logs.filter(l => l.direction === 'in').length})</option>
-            <option value="out">OUT ({logs.filter(l => l.direction === 'out').length})</option>
+            <option value="in">
+              IN ({logs.filter((l) => l.direction === 'in').length})
+            </option>
+            <option value="out">
+              OUT ({logs.filter((l) => l.direction === 'out').length})
+            </option>
+          </select>
+          <select
+            className="form-select retro-select me-2"
+            style={{ width: 'auto', fontSize: '12px' }}
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+          >
+            <option value="all">ALL TYPES</option>
+            {messageTypes.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <select
+            className="form-select retro-select me-2"
+            style={{ width: 'auto', fontSize: '12px' }}
+            value={deviceFilter}
+            onChange={(e) => setDeviceFilter(e.target.value)}
+          >
+            <option value="all">ALL DEVICES</option>
+            {devices.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
           </select>
           <button className="retro-button btn-sm me-2" onClick={clearLogs}>
             CLEAR
@@ -107,7 +156,9 @@ export default function MidiLogger({ onClose }: Props) {
               </span>
               <span className="log-type">{getMsgType(entry.message)}</span>
               <span className="log-data">{formatBytes(entry.message)}</span>
-              <span className="log-details">{getMessageDetails(entry.message)}</span>
+              <span className="log-details">
+                {getMessageDetails(entry.message)}
+              </span>
               {(entry.source || entry.target) && (
                 <span className="log-source">
                   ({entry.direction === 'in' ? entry.source : entry.target})

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -13,12 +13,16 @@ export default function SettingsModal({ onClose }: Props) {
   const reconnectInterval = useStore((s) => s.settings.reconnectInterval);
   const maxReconnectAttempts = useStore((s) => s.settings.maxReconnectAttempts);
   const logLimit = useStore((s) => s.settings.logLimit);
+  const pingInterval = useStore((s) => s.settings.pingInterval);
+  const pingThresholds = useStore((s) => s.settings.pingThresholds);
   const setHost = useStore((s) => s.setHost);
   const setPort = useStore((s) => s.setPort);
   const setAutoReconnect = useStore((s) => s.setAutoReconnect);
   const setReconnectInterval = useStore((s) => s.setReconnectInterval);
   const setMaxReconnectAttempts = useStore((s) => s.setMaxReconnectAttempts);
   const setLogLimit = useStore((s) => s.setLogLimit);
+  const setPingInterval = useStore((s) => s.setPingInterval);
+  const setPingThresholds = useStore((s) => s.setPingThresholds);
 
   const [h, setH] = useState(host);
   const [p, setP] = useState(port);
@@ -26,6 +30,10 @@ export default function SettingsModal({ onClose }: Props) {
   const [ri, setRi] = useState(reconnectInterval / 1000); // Convert to seconds for UI
   const [mra, setMra] = useState(maxReconnectAttempts);
   const [ll, setLl] = useState(logLimit);
+  const [pi, setPi] = useState(pingInterval / 1000);
+  const [green, setGreen] = useState(pingThresholds.green);
+  const [yellow, setYellow] = useState(pingThresholds.yellow);
+  const [orange, setOrange] = useState(pingThresholds.orange);
 
   const save = () => {
     setHost(h);
@@ -34,6 +42,8 @@ export default function SettingsModal({ onClose }: Props) {
     setReconnectInterval(Math.max(1, ri) * 1000); // Minimum 1 second, convert back to milliseconds
     setMaxReconnectAttempts(mra);
     setLogLimit(ll);
+    setPingInterval(Math.max(1, pi) * 1000);
+    setPingThresholds({ green, yellow, orange });
     onClose();
   };
 
@@ -59,10 +69,10 @@ export default function SettingsModal({ onClose }: Props) {
           <div className="modal-body">
             <div className="mb-3">
               <label className="form-label text-info">HOST ADDRESS:</label>
-              <input 
-                className="form-control retro-input" 
-                value={h} 
-                onChange={(e) => setH(e.target.value)} 
+              <input
+                className="form-control retro-input"
+                value={h}
+                onChange={(e) => setH(e.target.value)}
                 placeholder="localhost"
               />
               <small className="text-warning">Default: localhost</small>
@@ -92,6 +102,52 @@ export default function SettingsModal({ onClose }: Props) {
               <small className="text-warning">Default: 999</small>
             </div>
             <div className="mb-3">
+              <label className="form-label text-info">
+                PING INTERVAL (SECONDS):
+              </label>
+              <input
+                type="number"
+                className="form-control retro-input"
+                value={pi}
+                onChange={(e) => setPi(Number(e.target.value))}
+                min="1"
+                max="60"
+                step="0.5"
+              />
+              <small className="text-warning">Default: 15 seconds</small>
+            </div>
+            <div className="mb-3">
+              <label className="form-label text-info">
+                PING THRESHOLDS (MS):
+              </label>
+              <div className="d-flex gap-2">
+                <input
+                  type="number"
+                  className="form-control retro-input"
+                  value={green}
+                  onChange={(e) => setGreen(Number(e.target.value))}
+                  min="1"
+                />
+                <input
+                  type="number"
+                  className="form-control retro-input"
+                  value={yellow}
+                  onChange={(e) => setYellow(Number(e.target.value))}
+                  min="1"
+                />
+                <input
+                  type="number"
+                  className="form-control retro-input"
+                  value={orange}
+                  onChange={(e) => setOrange(Number(e.target.value))}
+                  min="1"
+                />
+              </div>
+              <small className="text-warning">
+                Green, Yellow, Orange defaults: 10/50/250
+              </small>
+            </div>
+            <div className="mb-3">
               <div className="form-check">
                 <input
                   type="checkbox"
@@ -100,39 +156,50 @@ export default function SettingsModal({ onClose }: Props) {
                   checked={ar}
                   onChange={(e) => setAr(e.target.checked)}
                 />
-                <label className="form-check-label text-info" htmlFor="autoReconnect">
+                <label
+                  className="form-check-label text-info"
+                  htmlFor="autoReconnect"
+                >
                   AUTO-RECONNECT ON FAILURE
                 </label>
               </div>
-              <small className="text-warning">Automatically reconnect when connection is lost</small>
+              <small className="text-warning">
+                Automatically reconnect when connection is lost
+              </small>
             </div>
             {ar && (
               <>
-              <div className="mb-3">
-                <label className="form-label text-info">RECONNECT INTERVAL (SECONDS):</label>
-                <input
-                  type="number"
-                  className="form-control retro-input"
-                  value={ri}
-                  onChange={(e) => setRi(Number(e.target.value))}
-                  min="1"
-                  max="60"
-                  step="0.5"
-                />
-                <small className="text-warning">Minimum: 1 second, Maximum: 60 seconds</small>
-              </div>
-              <div className="mb-3">
-                <label className="form-label text-info">MAX RECONNECT ATTEMPTS:</label>
-                <input
-                  type="number"
-                  className="form-control retro-input"
-                  value={mra}
-                  onChange={(e) => setMra(Number(e.target.value))}
-                  min="1"
-                  max="99"
-                />
-                <small className="text-warning">Default: 10</small>
-              </div>
+                <div className="mb-3">
+                  <label className="form-label text-info">
+                    RECONNECT INTERVAL (SECONDS):
+                  </label>
+                  <input
+                    type="number"
+                    className="form-control retro-input"
+                    value={ri}
+                    onChange={(e) => setRi(Number(e.target.value))}
+                    min="1"
+                    max="60"
+                    step="0.5"
+                  />
+                  <small className="text-warning">
+                    Minimum: 1 second, Maximum: 60 seconds
+                  </small>
+                </div>
+                <div className="mb-3">
+                  <label className="form-label text-info">
+                    MAX RECONNECT ATTEMPTS:
+                  </label>
+                  <input
+                    type="number"
+                    className="form-control retro-input"
+                    value={mra}
+                    onChange={(e) => setMra(Number(e.target.value))}
+                    min="1"
+                    max="99"
+                  />
+                  <small className="text-warning">Default: 10</small>
+                </div>
               </>
             )}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -40,8 +40,17 @@ body {
 }
 
 @keyframes glow {
-  from { text-shadow: 2px 2px 0px #ff00ff, 0 0 10px #ffff00; }
-  to { text-shadow: 2px 2px 0px #ff00ff, 0 0 20px #ffff00, 0 0 30px #ffff00; }
+  from {
+    text-shadow:
+      2px 2px 0px #ff00ff,
+      0 0 10px #ffff00;
+  }
+  to {
+    text-shadow:
+      2px 2px 0px #ff00ff,
+      0 0 20px #ffff00,
+      0 0 30px #ffff00;
+  }
 }
 
 .status-bar {
@@ -273,14 +282,47 @@ body {
   display: inline-block;
   padding: 4px 8px;
   font-family: 'VT323', monospace;
+}
+
+.ping-value.blue {
   background: #000040;
   color: #00ffff;
   border: 1px solid #00ffff;
 }
 
+.ping-value.green {
+  background: #004000;
+  color: #00ff00;
+  border: 1px solid #00ff00;
+}
+
+.ping-value.yellow {
+  background: #404000;
+  color: #ffff00;
+  border: 1px solid #ffff00;
+}
+
+.ping-value.orange {
+  background: #402000;
+  color: #ffb000;
+  border: 1px solid #ffb000;
+}
+
+.ping-value.red {
+  background: #400000;
+  color: #ff0000;
+  border: 1px solid #ff0000;
+}
+
 @keyframes blink {
-  0%, 50% { opacity: 1; }
-  51%, 100% { opacity: 0.3; }
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0.3;
+  }
 }
 
 .retro-select {
@@ -321,17 +363,18 @@ body {
   right: 0;
   bottom: 0;
   pointer-events: none;
-  background: linear-gradient(
-    transparent 50%,
-    rgba(0, 255, 0, 0.03) 50%
-  );
+  background: linear-gradient(transparent 50%, rgba(0, 255, 0, 0.03) 50%);
   background-size: 100% 4px;
   animation: scan 0.1s linear infinite;
 }
 
 @keyframes scan {
-  0% { transform: translateY(0); }
-  100% { transform: translateY(4px); }
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(4px);
+  }
 }
 
 /* Floating Action Bar */

--- a/src/store.ts
+++ b/src/store.ts
@@ -47,6 +47,12 @@ interface SettingsSlice {
     reconnectInterval: number;
     maxReconnectAttempts: number;
     logLimit: number;
+    pingInterval: number;
+    pingThresholds: {
+      green: number;
+      yellow: number;
+      orange: number;
+    };
   };
   setHost: (h: string) => void;
   setPort: (p: number) => void;
@@ -54,6 +60,10 @@ interface SettingsSlice {
   setReconnectInterval: (interval: number) => void;
   setMaxReconnectAttempts: (max: number) => void;
   setLogLimit: (limit: number) => void;
+  setPingInterval: (interval: number) => void;
+  setPingThresholds: (
+    t: Partial<{ green: number; yellow: number; orange: number }>,
+  ) => void;
 }
 
 type StoreState = DevicesSlice & MacrosSlice & PadsSlice & SettingsSlice;
@@ -92,29 +102,66 @@ export const useStore = create<StoreState>()(
         autoReconnect: true,
         reconnectInterval: 2000,
         maxReconnectAttempts: 10,
-        logLimit: 999
+        logLimit: 999,
+        pingInterval: 15000,
+        pingThresholds: { green: 10, yellow: 50, orange: 250 },
       },
-      setHost: (h) => set((state) => ({ settings: { ...state.settings, host: h } })),
-      setPort: (p) => set((state) => ({ settings: { ...state.settings, port: p } })),
-      setAutoReconnect: (enabled) => set((state) => ({ settings: { ...state.settings, autoReconnect: enabled } })),
-      setReconnectInterval: (interval) => set((state) => ({
-        settings: {
-          ...state.settings,
-          reconnectInterval: Math.max(1000, interval) // Minimum 1 second
-        }
-      })),
-      setMaxReconnectAttempts: (max) => set((state) => ({
-        settings: {
-          ...state.settings,
-          maxReconnectAttempts: Math.min(99, Math.max(1, max))
-        }
-      })),
-      setLogLimit: (limit) => set((state) => ({
-        settings: {
-          ...state.settings,
-          logLimit: Math.min(999, Math.max(1, limit))
-        }
-      })),
+      setHost: (h) =>
+        set((state) => ({ settings: { ...state.settings, host: h } })),
+      setPort: (p) =>
+        set((state) => ({ settings: { ...state.settings, port: p } })),
+      setAutoReconnect: (enabled) =>
+        set((state) => ({
+          settings: { ...state.settings, autoReconnect: enabled },
+        })),
+      setReconnectInterval: (interval) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            reconnectInterval: Math.max(1000, interval), // Minimum 1 second
+          },
+        })),
+      setMaxReconnectAttempts: (max) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            maxReconnectAttempts: Math.min(99, Math.max(1, max)),
+          },
+        })),
+      setLogLimit: (limit) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            logLimit: Math.min(999, Math.max(1, limit)),
+          },
+        })),
+      setPingInterval: (interval) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            pingInterval: Math.max(1000, interval),
+          },
+        })),
+      setPingThresholds: (t) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            pingThresholds: {
+              green: Math.max(
+                1,
+                t.green ?? state.settings.pingThresholds.green,
+              ),
+              yellow: Math.max(
+                1,
+                t.yellow ?? state.settings.pingThresholds.yellow,
+              ),
+              orange: Math.max(
+                1,
+                t.orange ?? state.settings.pingThresholds.orange,
+              ),
+            },
+          },
+        })),
     }),
     {
       name: 'store',

--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -23,10 +23,13 @@ export function useMidi() {
   const autoReconnect = useStore((s) => s.settings.autoReconnect);
   const reconnectInterval = useStore((s) => s.settings.reconnectInterval);
   const maxReconnectAttempts = useStore((s) => s.settings.maxReconnectAttempts);
+  const pingIntervalSetting = useStore((s) => s.settings.pingInterval);
   const selectedOutput = useStore((s) => s.devices.outputId);
   const [inputs, setInputs] = useState<MidiDevice[]>([]);
   const [outputs, setOutputs] = useState<MidiDevice[]>([]);
-  const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>('closed');
+  const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>(
+    'closed',
+  );
   const [pingDelay, setPingDelay] = useState<number | null>(null);
   const launchpadRef = useRef<number | null>(null);
   const listeners = useRef(new Set<(msg: MidiMessage) => void>());
@@ -38,9 +41,15 @@ export function useMidi() {
   const connectionAttemptsRef = useRef(0);
 
   const sendPing = useCallback(() => {
-    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+    if (
+      wsRef.current &&
+      wsRef.current.readyState === WebSocket.OPEN &&
+      pingSentAtRef.current === null
+    ) {
       pingSentAtRef.current = Date.now();
-      wsRef.current.send(JSON.stringify({ type: 'ping', ts: pingSentAtRef.current }));
+      wsRef.current.send(
+        JSON.stringify({ type: 'ping', ts: pingSentAtRef.current }),
+      );
     }
   }, []);
 
@@ -65,7 +74,7 @@ export function useMidi() {
       console.log('Page not fully loaded yet, waiting...');
       return;
     }
-    
+
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       console.log('WebSocket already connected');
       return;
@@ -76,20 +85,22 @@ export function useMidi() {
       wsRef.current.close();
     }
 
-    console.log(`Attempting WebSocket connection to ws://${host}:${port} (attempt ${connectionAttemptsRef.current + 1})`);
+    console.log(
+      `Attempting WebSocket connection to ws://${host}:${port} (attempt ${connectionAttemptsRef.current + 1})`,
+    );
     setStatus('connecting');
-    
+
     try {
       const ws = new WebSocket(`ws://${host}:${port}`);
       wsRef.current = ws;
-      
+
       const connectionTimeout = setTimeout(() => {
         if (ws.readyState === WebSocket.CONNECTING) {
           console.log('Connection timeout, closing WebSocket');
           ws.close();
         }
       }, 5000); // 5 second timeout
-      
+
       ws.onopen = () => {
         clearTimeout(connectionTimeout);
         console.log('WebSocket connected successfully');
@@ -99,18 +110,18 @@ export function useMidi() {
         // Start ping interval
         if (pingIntervalRef.current) clearInterval(pingIntervalRef.current);
         sendPing();
-        pingIntervalRef.current = setInterval(sendPing, 15000);
+        pingIntervalRef.current = setInterval(sendPing, pingIntervalSetting);
 
         // Request device list
         ws.send(JSON.stringify({ type: 'getDevices' }));
-        
+
         // Clear any pending reconnect
         if (reconnectTimeoutRef.current) {
           clearTimeout(reconnectTimeoutRef.current);
           reconnectTimeoutRef.current = null;
         }
       };
-      
+
       ws.onmessage = (ev) => {
         try {
           const payload = JSON.parse(ev.data);
@@ -118,6 +129,7 @@ export function useMidi() {
           if (payload.type === 'pong' && typeof payload.ts === 'number') {
             if (pingSentAtRef.current !== null) {
               setPingDelay(Date.now() - payload.ts);
+              pingSentAtRef.current = null;
             }
             return;
           }
@@ -126,16 +138,15 @@ export function useMidi() {
             console.log('Received device list:', payload);
             setInputs(payload.inputs || []);
             setOutputs(payload.outputs || []);
-            
+
             // Find Launchpad X
             const launchpad = payload.outputs?.find((o: MidiDevice) =>
-              o.name?.toLowerCase().includes('launchpad x')
+              o.name?.toLowerCase().includes('launchpad x'),
             );
             launchpadRef.current = launchpad ? launchpad.id : null;
             if (launchpad) {
               console.log('Launchpad X detected:', launchpad);
             }
-            
           } else if (payload.type === 'midi') {
             const msg: MidiMessage = {
               direction: payload.direction || 'in',
@@ -143,9 +154,9 @@ export function useMidi() {
               timestamp: payload.timestamp || Date.now(),
               source: payload.source,
               target: payload.target,
-              port: payload.port
+              port: payload.port,
             };
-            
+
             for (const fn of listeners.current) {
               fn(msg);
             }
@@ -154,22 +165,32 @@ export function useMidi() {
           console.error('WebSocket message parse error:', err);
         }
       };
-      
+
       ws.onclose = (event) => {
         clearTimeout(connectionTimeout);
         console.log('WebSocket disconnected:', event.code, event.reason);
         setStatus('closed');
+        pingSentAtRef.current = null;
         if (pingIntervalRef.current) {
           clearInterval(pingIntervalRef.current);
           pingIntervalRef.current = null;
         }
-        
+
         // Auto-reconnect if enabled and not too many attempts
-        if (autoReconnect && connectionAttemptsRef.current < maxReconnectAttempts && !reconnectTimeoutRef.current) {
+        if (
+          autoReconnect &&
+          connectionAttemptsRef.current < maxReconnectAttempts &&
+          !reconnectTimeoutRef.current
+        ) {
           connectionAttemptsRef.current++;
-          const delay = Math.min(reconnectInterval * connectionAttemptsRef.current, 30000); // Max 30s delay
-          console.log(`Reconnecting in ${delay}ms... (attempt ${connectionAttemptsRef.current}/${maxReconnectAttempts})`);
-          
+          const delay = Math.min(
+            reconnectInterval * connectionAttemptsRef.current,
+            30000,
+          ); // Max 30s delay
+          console.log(
+            `Reconnecting in ${delay}ms... (attempt ${connectionAttemptsRef.current}/${maxReconnectAttempts})`,
+          );
+
           reconnectTimeoutRef.current = setTimeout(() => {
             reconnectTimeoutRef.current = null;
             connectWebSocket();
@@ -178,22 +199,30 @@ export function useMidi() {
           console.log('Max reconnection attempts reached');
         }
       };
-      
+
       ws.onerror = (err) => {
         clearTimeout(connectionTimeout);
         console.error('WebSocket error:', err);
         setStatus('closed');
+        pingSentAtRef.current = null;
         if (pingIntervalRef.current) {
           clearInterval(pingIntervalRef.current);
           pingIntervalRef.current = null;
         }
       };
-      
     } catch (err) {
       console.error('Failed to create WebSocket:', err);
       setStatus('closed');
     }
-  }, [host, port, autoReconnect, reconnectInterval, maxReconnectAttempts, sendPing]);
+  }, [
+    host,
+    port,
+    autoReconnect,
+    reconnectInterval,
+    maxReconnectAttempts,
+    sendPing,
+    pingIntervalSetting,
+  ]);
 
   // Manual reconnect function
   const reconnect = useCallback(() => {
@@ -227,6 +256,15 @@ export function useMidi() {
     }
   }, [host, port]);
 
+  useEffect(() => {
+    if (status === 'connected') {
+      if (pingIntervalRef.current) {
+        clearInterval(pingIntervalRef.current);
+      }
+      pingIntervalRef.current = setInterval(sendPing, pingIntervalSetting);
+    }
+  }, [pingIntervalSetting, status, sendPing]);
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -245,31 +283,40 @@ export function useMidi() {
   const send = useCallback(
     (bytes: number[] | Uint8Array) => {
       if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
-        console.warn('Cannot send MIDI: WebSocket not connected (status:', status, ')');
+        console.warn(
+          'Cannot send MIDI: WebSocket not connected (status:',
+          status,
+          ')',
+        );
         return false;
       }
 
       // Use selected output device, fallback to Launchpad X, then default to 0
-      const targetPort = selectedOutput ? Number(selectedOutput) : 
-                        launchpadRef.current !== null ? launchpadRef.current : 0;
-      
+      const targetPort = selectedOutput
+        ? Number(selectedOutput)
+        : launchpadRef.current !== null
+          ? launchpadRef.current
+          : 0;
+
       const bytesArray = Array.from(bytes);
-      
+
       console.log('Sending MIDI to port', targetPort, ':', bytesArray);
-      
+
       try {
-        wsRef.current.send(JSON.stringify({ 
-          type: 'send', 
-          port: targetPort, 
-          bytes: bytesArray 
-        }));
+        wsRef.current.send(
+          JSON.stringify({
+            type: 'send',
+            port: targetPort,
+            bytes: bytesArray,
+          }),
+        );
         return true;
       } catch (err) {
         console.error('Failed to send MIDI:', err);
         return false;
       }
     },
-    [selectedOutput, status]
+    [selectedOutput, status],
   );
 
   const listen = useCallback((handler: (msg: MidiMessage) => void) => {
@@ -297,6 +344,6 @@ export function useMidi() {
     status,
     pingDelay,
     launchpadDetected: launchpadRef.current !== null,
-    reconnect
+    reconnect,
   };
 }


### PR DESCRIPTION
## Summary
- filter MIDI log by message type and device
- color ping box by connection latency
- store ping interval and thresholds in settings
- expose ping settings in config UI
- throttle ping messages

## Testing
- `npm install`
- `npm run lint` *(fails: 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686ac6fb86fc8325a1721b9d4f8cbca5