### PR TITLE
fix duplicate key warning in LaunchpadCanvas

### DIFF
--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -63,7 +63,7 @@ const Pad = memo(({ id, note, cc: ccNum, isEmpty }: PadProps) => {
       >
         {LAUNCHPAD_COLORS.map((color) => (
           <option
-            key={color.name}
+            key={color.value}
             value={color.color}
             style={{
               backgroundColor: color.color,


### PR DESCRIPTION
## Summary
- ensure unique option keys for Launchpad colors

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686acf7cb35c8325808800546c21bdfa