### PR TITLE
Update log limits and rename Launchpad controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
             </div>
             <div className="col-md-6">
               <div className="retro-panel">
-                <h3>◄ Launchpad X Control Matrix ►</h3>
+                <h3>◄ Launchpad Mission Control ►</h3>
                 <LaunchpadCanvas />
               </div>
             </div>

--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -88,18 +88,18 @@ export function LaunchpadCanvas() {
     grid.push(<Pad key={id} id={id} cc={TOP_CC[x]} />);
   }
 
-  // Main 8x8 grid with side controls
+  // Main 8x8 grid with side controls moved to the right
   for (let y = 0; y < 8; y++) {
-    // Side CC control (left)
-    const sideId = `cc-${SIDE_CC[y]}`;
-    grid.push(<Pad key={sideId} id={sideId} cc={SIDE_CC[y]} />);
-
     // Main 8x8 note grid
     for (let x = 0; x < 8; x++) {
       const note = NOTE_GRID[y][x];
       const id = `n-${note}`;
       grid.push(<Pad key={id} id={id} note={note} />);
     }
+
+    // Side CC control (right)
+    const sideId = `cc-${SIDE_CC[y]}`;
+    grid.push(<Pad key={sideId} id={sideId} cc={SIDE_CC[y]} />);
   }
 
   return <div className="midi-grid-fixed">{grid}</div>;

--- a/src/LaunchpadControls.tsx
+++ b/src/LaunchpadControls.tsx
@@ -84,7 +84,7 @@ export default function LaunchpadControls() {
 
   return (
     <div className="retro-panel">
-      <h3>◄ Launchpad X Control Matrix ►</h3>
+      <h3>◄ Launchpad Toolbox Matrix ►</h3>
 
       <div className="row mb-3">
         <div className="col-md-4">

--- a/src/MidiLogger.tsx
+++ b/src/MidiLogger.tsx
@@ -27,7 +27,10 @@ export default function MidiLogger({ onClose }: Props) {
     if (bytes.length === 0) return 'EMPTY';
     const status = bytes[0];
     if (status >= 0x80 && status <= 0x8F) return 'NOTE_OFF';
-    if (status >= 0x90 && status <= 0x9F) return 'NOTE_ON';
+    if (status >= 0x90 && status <= 0x9F) {
+      if (bytes.length >= 3 && bytes[2] === 0) return 'NOTE_OFF';
+      return 'NOTE_ON';
+    }
     if (status >= 0xA0 && status <= 0xAF) return 'AFTERTOUCH';
     if (status >= 0xB0 && status <= 0xBF) return 'CC';
     if (status >= 0xC0 && status <= 0xCF) return 'PROG_CHG';

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -107,9 +107,9 @@ export default function SettingsModal({ onClose }: Props) {
                 value={ll}
                 onChange={(e) => setLl(Number(e.target.value))}
                 min="1"
-                max="999"
+                max="9999"
               />
-              <small className="text-warning">Default: 999</small>
+              <small className="text-warning">Default: 9999</small>
             </div>
             <div className="mb-3">
               <label className="form-label text-info">

--- a/src/logStore.ts
+++ b/src/logStore.ts
@@ -23,7 +23,7 @@ export const useLogStore = create<LogStoreState>((set) => ({
       id: idCounter++,
       formattedTime: new Date(msg.timestamp).toLocaleTimeString(),
     };
-    const limit = useStore.getState().settings.logLimit || 999;
+    const limit = useStore.getState().settings.logLimit || 9999;
     set((state) => ({ logs: [...state.logs.slice(-(limit - 1)), entry] }));
   },
   clearLogs: () => set({ logs: [] }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -102,7 +102,7 @@ export const useStore = create<StoreState>()(
         autoReconnect: true,
         reconnectInterval: 2000,
         maxReconnectAttempts: 10,
-        logLimit: 999,
+        logLimit: 9999,
         pingInterval: 15000,
         pingGreen: 10,
         pingYellow: 50,
@@ -135,7 +135,7 @@ export const useStore = create<StoreState>()(
         set((state) => ({
           settings: {
             ...state.settings,
-            logLimit: Math.min(999, Math.max(1, limit)),
+            logLimit: Math.min(9999, Math.max(1, limit)),
           },
         })),
       setPingInterval: (interval) =>


### PR DESCRIPTION
## Summary
- log more entries by default
- detect note off when velocity is zero
- move Launchpad CC column to the right
- rename Launchpad UI sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ad8ad8724832594ad146e32ceb400