### PR TITLE
Add MIDI pressure handling

### DIFF
--- a/src/MidiLogger.tsx
+++ b/src/MidiLogger.tsx
@@ -61,6 +61,12 @@ export default function MidiLogger({ onClose }: Props) {
     if (status >= 0x80 && status <= 0x8F && bytes.length >= 3) {
       return `Ch${(status & 0x0F) + 1} Note:${bytes[1]} Vel:${bytes[2]}`;
     }
+    if (status >= 0xA0 && status <= 0xAF && bytes.length >= 3) {
+      return `Ch${(status & 0x0F) + 1} Note:${bytes[1]} Pressure:${bytes[2]}`;
+    }
+    if (status >= 0xD0 && status <= 0xDF && bytes.length >= 2) {
+      return `Ch${(status & 0x0F) + 1} Pressure:${bytes[1]}`;
+    }
     if (status >= 0xB0 && status <= 0xBF && bytes.length >= 3) {
       return `Ch${(status & 0x0F) + 1} CC:${bytes[1]} Val:${bytes[2]}`;
     }

--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -15,6 +15,7 @@ export interface MidiMessage {
   source?: string;
   target?: string;
   port?: number;
+  pressure?: number;
 }
 
 export function useMidi() {
@@ -164,6 +165,7 @@ export function useMidi() {
               source: payload.source,
               target: payload.target,
               port: payload.port,
+              pressure: payload.pressure,
             };
 
             for (const fn of listeners.current) {

--- a/src/useRecorder.ts
+++ b/src/useRecorder.ts
@@ -14,12 +14,12 @@ export function useRecorder(isRecording: boolean) {
       return;
     }
     const handler = (msg: MidiMessage) => {
-      const { data } = msg;
+      const { message } = msg;
       const now = performance.now();
       const prev = lastTime.current ?? now;
       lastTime.current = now;
       const delta = now - prev;
-      const bytes = Array.from(data);
+      const bytes = Array.from(message);
       setMessages((msgs) => [...msgs, { ts: delta, bytes }]);
     };
     const unlisten = listen(handler);


### PR DESCRIPTION
## Summary
- include pressure data for polyphonic and channel aftertouch
- expose pressure in the MidiMessage interface
- display pressure info in the logger
- fix recorder to use `message` field

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686adc21a858832590e91e86d0578923