### PR TITLE
Add pad configuration panel and custom configs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import SysexWorkbench from './SysexWorkbench';
 import MidiDevices from './MidiDevices';
 import ActionBar from './ActionBar';
 import FloatingActionBar from './FloatingActionBar';
+import ConfigManager from './ConfigManager';
 import './App.css';
 
 function App() {
@@ -13,9 +14,7 @@ function App() {
       <div className="scan-lines"></div>
       <div className="container-fluid">
         <div className="retro-container">
-          <h1 className="retro-title">
-            ◄ AutoMIDI v2.0 ►
-          </h1>
+          <h1 className="retro-title">◄ AutoMIDI v2.0 ►</h1>
           <ActionBar />
           <div className="row">
             <div className="col-md-6">
@@ -39,6 +38,11 @@ function App() {
             </div>
             <div className="col-md-6">
               <SysexWorkbench />
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-12">
+              <ConfigManager />
             </div>
           </div>
         </div>

--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useStore, type PadConfig } from './store';
+
+export default function ConfigManager() {
+  const configs = useStore((s) => s.configs);
+  const addConfig = useStore((s) => s.addConfig);
+  const removeConfig = useStore((s) => s.removeConfig);
+  const setPadColours = useStore((s) => s.setPadColours);
+  const padColours = useStore((s) => s.padColours);
+  const [name, setName] = useState('');
+
+  const saveCurrent = () => {
+    if (!name.trim()) return;
+    const cfg: PadConfig = {
+      id: Date.now().toString(),
+      name: name.trim(),
+      padColours,
+    };
+    addConfig(cfg);
+    setName('');
+  };
+
+  const loadConfig = (cfg: PadConfig) => {
+    setPadColours(cfg.padColours);
+  };
+
+  const exportConfig = (cfg: PadConfig) => {
+    const data = JSON.stringify(cfg);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${cfg.name}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importConfig = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const cfg = JSON.parse(ev.target?.result as string) as PadConfig;
+        addConfig({ ...cfg, id: Date.now().toString() });
+      } catch {
+        /* ignore */
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  return (
+    <div className="retro-panel">
+      <h3>◄ Custom Configs ►</h3>
+      <div className="mb-3 d-flex">
+        <input
+          className="form-control retro-input me-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Config name"
+        />
+        <button className="retro-button btn-sm" onClick={saveCurrent}>
+          SAVE
+        </button>
+      </div>
+      <div className="mb-3">
+        <input type="file" accept="application/json" onChange={importConfig} />
+      </div>
+      {configs.map((cfg) => (
+        <div key={cfg.id} className="macro-list-item">
+          <span className="macro-name">{cfg.name}</span>
+          <div>
+            <button
+              className="retro-button btn-sm me-1"
+              onClick={() => loadConfig(cfg)}
+            >
+              LOAD
+            </button>
+            <button
+              className="retro-button btn-sm me-1"
+              onClick={() => exportConfig(cfg)}
+            >
+              EXPORT
+            </button>
+            <button
+              className="retro-button btn-sm"
+              onClick={() => removeConfig(cfg.id)}
+            >
+              DEL
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -1,0 +1,65 @@
+import { useStore } from './store';
+import { useMidi } from './useMidi';
+import { noteOn, cc } from './midiMessages';
+import LAUNCHPAD_COLORS from './launchpadColors';
+
+interface PadInfo {
+  id: string;
+  note?: number;
+  cc?: number;
+}
+
+interface Props {
+  pad: PadInfo;
+  onClose: () => void;
+}
+
+export default function PadOptionsPanel({ pad, onClose }: Props) {
+  const colour = useStore((s) => s.padColours[pad.id] || '#000000');
+  const setPadColour = useStore((s) => s.setPadColour);
+  const { send, status } = useMidi();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = LAUNCHPAD_COLORS.find((c) => c.color === e.target.value);
+    if (!selected) return;
+    setPadColour(pad.id, selected.color);
+    if (status === 'connected') {
+      if (pad.note !== undefined) {
+        send(noteOn(pad.note, selected.value));
+      } else if (pad.cc !== undefined) {
+        send(cc(pad.cc, selected.value));
+      }
+    }
+  };
+
+  return (
+    <div className="pad-options-panel" onClick={(e) => e.stopPropagation()}>
+      <h4>PAD {pad.id}</h4>
+      <div className="mb-3">
+        <label className="form-label text-info">COLOR:</label>
+        <select
+          className="form-select retro-select"
+          value={colour}
+          onChange={handleChange}
+          style={{ backgroundColor: colour }}
+        >
+          {LAUNCHPAD_COLORS.map((color) => (
+            <option
+              key={color.value}
+              value={color.color}
+              style={{
+                backgroundColor: color.color,
+                color: color.color === '#000000' ? '#fff' : '#000',
+              }}
+            >
+              {color.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button className="retro-button" onClick={onClose}>
+        CLOSE
+      </button>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -40,8 +40,17 @@ body {
 }
 
 @keyframes glow {
-  from { text-shadow: 2px 2px 0px #ff00ff, 0 0 10px #ffff00; }
-  to { text-shadow: 2px 2px 0px #ff00ff, 0 0 20px #ffff00, 0 0 30px #ffff00; }
+  from {
+    text-shadow:
+      2px 2px 0px #ff00ff,
+      0 0 10px #ffff00;
+  }
+  to {
+    text-shadow:
+      2px 2px 0px #ff00ff,
+      0 0 20px #ffff00,
+      0 0 30px #ffff00;
+  }
 }
 
 .status-bar {
@@ -69,47 +78,15 @@ body {
   width: 100%;
   height: 100%;
   position: relative;
-}
-#n-54::after,
-#n-55::after,
-#n-45::after,
-#n-44::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 60%;
-  height: 60%;
-  transform: translate(-50%, -50%) rotate(45deg);
-  border: 1px solid #ffff00;
-  pointer-events: none;
-}
-
-.midi-pad-select {
-  width: 100%;
-  height: 100%;
   border: 1px solid #00ff00;
   background: #000040;
   cursor: pointer;
   transition: all 0.1s;
-  font-family: 'VT323', monospace;
-  font-size: 10px;
-  color: transparent;
-  text-align: center;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
 }
 
-.midi-pad-select:hover {
+.midi-pad-container:hover {
   border-color: #ffff00;
   box-shadow: 0 0 10px #ffff00;
-}
-
-.midi-pad-select:focus {
-  outline: none;
-  border-color: #ffff00;
-  box-shadow: 0 0 15px #ffff00;
 }
 
 .midi-pad-empty {
@@ -117,6 +94,22 @@ body {
   height: 100%;
   background: transparent;
   border: 1px solid #333;
+}
+
+#n-45 .midi-pad-container {
+  border-radius: 20px 0 0 0;
+}
+#n-44 .midi-pad-container {
+  border-radius: 0 20px 0 0;
+}
+#n-55 .midi-pad-container {
+  border-radius: 0 0 0 20px;
+}
+#n-54 .midi-pad-container {
+  border-radius: 0 0 20px 0;
+}
+#cc-99 .midi-pad-container {
+  border-radius: 5px;
 }
 
 .retro-panel {
@@ -323,8 +316,14 @@ body {
 }
 
 @keyframes blink {
-  0%, 50% { opacity: 1; }
-  51%, 100% { opacity: 0.3; }
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0.3;
+  }
 }
 
 .retro-select {
@@ -365,17 +364,18 @@ body {
   right: 0;
   bottom: 0;
   pointer-events: none;
-  background: linear-gradient(
-    transparent 50%,
-    rgba(0, 255, 0, 0.03) 50%
-  );
+  background: linear-gradient(transparent 50%, rgba(0, 255, 0, 0.03) 50%);
   background-size: 100% 4px;
   animation: scan 0.1s linear infinite;
 }
 
 @keyframes scan {
-  0% { transform: translateY(0); }
-  100% { transform: translateY(4px); }
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(4px);
+  }
 }
 
 /* Floating Action Bar */
@@ -529,4 +529,25 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #ffff00;
+}
+
+/* Side panel for pad options */
+.pad-options-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 220px;
+  height: 100%;
+  background: #000040;
+  border-left: 2px solid #00ffff;
+  box-shadow: -2px 0 10px #00ffff;
+  padding: 20px;
+  z-index: 1100;
+  overflow-y: auto;
+}
+
+.pad-options-panel h4 {
+  margin-top: 0;
+  color: #ffff00;
+  text-transform: uppercase;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,6 +37,20 @@ interface MacrosSlice {
 interface PadsSlice {
   padColours: Record<string, string>;
   setPadColour: (id: string, colour: string) => void;
+  setPadColours: (colours: Record<string, string>) => void;
+}
+
+export interface PadConfig {
+  id: string;
+  name: string;
+  padColours: Record<string, string>;
+}
+
+interface ConfigsSlice {
+  configs: PadConfig[];
+  addConfig: (c: PadConfig) => void;
+  updateConfig: (c: PadConfig) => void;
+  removeConfig: (id: string) => void;
 }
 
 interface SettingsSlice {
@@ -66,7 +80,11 @@ interface SettingsSlice {
   setPingEnabled: (enabled: boolean) => void;
 }
 
-type StoreState = DevicesSlice & MacrosSlice & PadsSlice & SettingsSlice;
+type StoreState = DevicesSlice &
+  MacrosSlice &
+  PadsSlice &
+  SettingsSlice &
+  ConfigsSlice;
 
 const kvStore = createIdbStore('automidi-db', 'state');
 
@@ -96,6 +114,15 @@ export const useStore = create<StoreState>()(
       padColours: {},
       setPadColour: (id, colour) =>
         set((state) => ({ padColours: { ...state.padColours, [id]: colour } })),
+      setPadColours: (colours) => set(() => ({ padColours: { ...colours } })),
+      configs: [],
+      addConfig: (c) => set((s) => ({ configs: [...s.configs, c] })),
+      updateConfig: (c) =>
+        set((s) => ({
+          configs: s.configs.map((p) => (p.id === c.id ? c : p)),
+        })),
+      removeConfig: (id) =>
+        set((s) => ({ configs: s.configs.filter((p) => p.id !== id) })),
       settings: {
         host: location.hostname || 'localhost',
         port: 3000,


### PR DESCRIPTION
## Summary
- refactor LaunchpadCanvas pads to open a side options panel
- add PadOptionsPanel component for editing pad colour
- add ConfigManager component with load/save/delete/export/import
- extend store to keep custom configurations
- update styles for pads, central pad rounding and cc99 rounding
- add side panel styling and remove old slanted indicator

## Testing
- `npx prettier --write src/App.tsx src/LaunchpadCanvas.tsx src/PadOptionsPanel.tsx src/ConfigManager.tsx src/store.ts src/index.css`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ae4e831748325a245cdf96f0ec879