### PR TITLE
Adjust launchpad UI styles

### DIFF
--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -31,8 +31,12 @@ const Pad = memo(
     cc: ccNum,
     isEmpty,
     onSelect,
+    selected,
+    extraClass,
   }: PadProps & {
     onSelect: (p: { id: string; note?: number; cc?: number }) => void;
+    selected?: boolean;
+    extraClass?: string;
   }) => {
     const colour = useStore((s) => s.padColours[id] || '#000000');
 
@@ -42,7 +46,9 @@ const Pad = memo(
 
     return (
       <div
-        className="midi-pad-container"
+        className={`midi-pad-container ${selected ? 'selected' : ''} ${
+          extraClass || ''
+        }`}
         id={id}
         style={{ backgroundColor: colour }}
         title={note !== undefined ? `Note ${note}` : `CC ${ccNum}`}
@@ -55,11 +61,20 @@ const Pad = memo(
 export function LaunchpadCanvas() {
   const [selected, setSelected] = useState<PadProps | null>(null);
   const grid: React.ReactElement[] = [];
-
+  
   // Top row - 9 CC controls
   for (let x = 0; x < 9; x++) {
     const id = `cc-${TOP_CC[x]}`;
-    grid.push(<Pad key={id} id={id} cc={TOP_CC[x]} onSelect={setSelected} />);
+    grid.push(
+      <Pad
+        key={id}
+        id={id}
+        cc={TOP_CC[x]}
+        onSelect={setSelected}
+        selected={selected?.id === id}
+        extraClass="top-cc"
+      />,
+    );
   }
 
   // Main 8x8 grid with side controls moved to the right
@@ -68,13 +83,28 @@ export function LaunchpadCanvas() {
     for (let x = 0; x < 8; x++) {
       const note = NOTE_GRID[y][x];
       const id = `n-${note}`;
-      grid.push(<Pad key={id} id={id} note={note} onSelect={setSelected} />);
+      grid.push(
+        <Pad
+          key={id}
+          id={id}
+          note={note}
+          onSelect={setSelected}
+          selected={selected?.id === id}
+        />,
+      );
     }
 
     // Side CC control (right)
     const sideId = `cc-${SIDE_CC[y]}`;
     grid.push(
-      <Pad key={sideId} id={sideId} cc={SIDE_CC[y]} onSelect={setSelected} />,
+      <Pad
+        key={sideId}
+        id={sideId}
+        cc={SIDE_CC[y]}
+        onSelect={setSelected}
+        selected={selected?.id === sideId}
+        extraClass="side-cc"
+      />,
     );
   }
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,26 @@ body {
   }
 }
 
+@keyframes pulse-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 5px #00ffff;
+  }
+  50% {
+    box-shadow: 0 0 15px #00ffff;
+  }
+}
+
+@keyframes pulse-shadow {
+  0%,
+  100% {
+    box-shadow: 0 0 20px #00ffff;
+  }
+  50% {
+    box-shadow: 0 0 30px #00ffff;
+  }
+}
+
 .status-bar {
   background: #000040;
   border: 1px solid #00ff00;
@@ -82,6 +102,19 @@ body {
   background: #000040;
   cursor: pointer;
   transition: all 0.1s;
+}
+
+.midi-pad-container.top-cc {
+  margin-bottom: 2px;
+}
+
+.midi-pad-container.side-cc {
+  margin-left: 2px;
+}
+
+.midi-pad-container.selected {
+  animation: pulse-glow 1s infinite;
+  box-shadow: 0 0 10px #00ffff;
 }
 
 .midi-pad-container:hover {
@@ -117,6 +150,7 @@ body {
   border: 2px solid #00ff00;
   margin: 15px 0;
   padding: 15px;
+  position: relative;
 }
 
 .retro-panel h3 {
@@ -234,6 +268,7 @@ body {
   background: #000080 !important;
   border: 3px solid #00ffff !important;
   box-shadow: 0 0 30px #00ffff !important;
+  animation: pulse-shadow 2s infinite;
 }
 
 .modal-retro .modal-header {
@@ -533,7 +568,7 @@ body {
 
 /* Side panel for pad options */
 .pad-options-panel {
-  position: fixed;
+  position: absolute;
   top: 0;
   right: 0;
   width: 220px;


### PR DESCRIPTION
## Summary
- highlight selected grid buttons with a pulsating glow
- keep Launchpad options panel inside the mission control panel
- space launchpad control rows and columns
- animate the retro modal shadow

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ae9463ddc832595bb0929e1c309ae