### PR TITLE
Fix selector for cc-99 margin

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -141,7 +141,7 @@ body {
 #n-54 .midi-pad-container {
   border-radius: 0 0 20px 0;
 }
-#cc-99 .midi-pad-container {
+#cc-99.midi-pad-container {
   border-radius: 5px;
   margin-left: 10px;
 }


### PR DESCRIPTION
## Summary
- fix CSS selector so `cc-99` pad gets a left margin

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find namespace 'NodeJS')*

------
https://chatgpt.com/codex/tasks/task_e_686af4b3fcac8325a3e30a5423d4bb5d