### PR TITLE
Add launchpad loading and clearing options

### DIFF
--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -7,6 +7,9 @@ export default function ConfigManager() {
   const removeConfig = useStore((s) => s.removeConfig);
   const setPadColours = useStore((s) => s.setPadColours);
   const padColours = useStore((s) => s.padColours);
+  const updateConfig = useStore((s) => s.updateConfig);
+  const [editing, setEditing] = useState<PadConfig | null>(null);
+  const [editName, setEditName] = useState('');
   const [name, setName] = useState('');
 
   const saveCurrent = () => {
@@ -22,6 +25,17 @@ export default function ConfigManager() {
 
   const loadConfig = (cfg: PadConfig) => {
     setPadColours(cfg.padColours);
+  };
+
+  const startEdit = (cfg: PadConfig) => {
+    setEditing(cfg);
+    setEditName(cfg.name);
+  };
+
+  const saveEdit = () => {
+    if (!editing) return;
+    updateConfig({ ...editing, name: editName.trim() || editing.name });
+    setEditing(null);
   };
 
   const exportConfig = (cfg: PadConfig) => {
@@ -85,6 +99,12 @@ export default function ConfigManager() {
               EXPORT
             </button>
             <button
+              className="retro-button btn-sm me-1"
+              onClick={() => startEdit(cfg)}
+            >
+              EDIT
+            </button>
+            <button
               className="retro-button btn-sm"
               onClick={() => removeConfig(cfg.id)}
             >
@@ -93,6 +113,24 @@ export default function ConfigManager() {
           </div>
         </div>
       ))}
+      {editing && (
+        <div className="retro-panel mt-3">
+          <h4 className="text-warning">EDIT CONFIG</h4>
+          <div className="mb-3">
+            <input
+              className="form-control retro-input"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+            />
+          </div>
+          <button className="retro-button me-2" onClick={saveEdit}>
+            SAVE
+          </button>
+          <button className="retro-button" onClick={() => setEditing(null)}>
+            CANCEL
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -19,6 +19,17 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
   const setPadColour = useStore((s) => s.setPadColour);
   const { send, status } = useMidi();
 
+  const clearPad = () => {
+    setPadColour(pad.id, '#000000');
+    if (status === 'connected') {
+      if (pad.note !== undefined) {
+        send(noteOn(pad.note, 0));
+      } else if (pad.cc !== undefined) {
+        send(cc(pad.cc, 0));
+      }
+    }
+  };
+
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selected = LAUNCHPAD_COLORS.find((c) => c.color === e.target.value);
     if (!selected) return;
@@ -57,6 +68,9 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
           ))}
         </select>
       </div>
+      <button className="retro-button me-2" onClick={clearPad}>
+        CLEAR
+      </button>
       <button className="retro-button" onClick={onClose}>
         CLOSE
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,7 @@ body {
 }
 
 .midi-pad-container.top-cc {
-  margin-bottom: 2px;
+  margin-bottom: 10px;
 }
 
 .midi-pad-container.side-cc {
@@ -129,16 +129,16 @@ body {
   border: 1px solid #333;
 }
 
-#n-45 .midi-pad-container {
+#n-45.midi-pad-container {
   border-radius: 20px 0 0 0;
 }
-#n-44 .midi-pad-container {
+#n-44.midi-pad-container {
   border-radius: 0 20px 0 0;
 }
-#n-55 .midi-pad-container {
+#n-55.midi-pad-container {
   border-radius: 0 0 0 20px;
 }
-#n-54 .midi-pad-container {
+#n-54.midi-pad-container {
   border-radius: 0 0 20px 0;
 }
 #cc-99.midi-pad-container {


### PR DESCRIPTION
## Summary
- tweak pad corner CSS selectors and spacing
- add functions to load pad colours into Launchpad
- support clearing config and pads
- allow renaming configs via edit panel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_686af9088de88325b116652c08a3fa6f