### PR TITLE
Add MIDI clock support and UI tweaks

### DIFF
--- a/src/LaunchpadControls.tsx
+++ b/src/LaunchpadControls.tsx
@@ -18,6 +18,7 @@ import {
   setLedFlashing,
   setLedPulsing,
   CHANNEL_STATIC,
+  midiClock,
 } from './midiMessages';
 
 export default function LaunchpadControls() {
@@ -26,6 +27,7 @@ export default function LaunchpadControls() {
   const padChannels = useStore((s) => s.padChannels);
   const setPadColours = useStore((s) => s.setPadColours);
   const setPadChannels = useStore((s) => s.setPadChannels);
+  const clockBytes = useStore((s) => s.settings.clock);
   const addToast = useToastStore((s) => s.addToast);
   const notify = (ok: boolean, action: string) => {
     addToast(
@@ -124,6 +126,11 @@ export default function LaunchpadControls() {
     for (let i = 21; i <= 28; i++) {
       send(setLedPulsing(i, 51)); // Green pulsing
     }
+  };
+
+  const handleSendClock = () => {
+    const bytes = clockBytes.length ? clockBytes : midiClock();
+    notify(send(bytes), 'Clock');
   };
 
   return (
@@ -268,6 +275,9 @@ export default function LaunchpadControls() {
           </button>
           <button className="retro-button me-2" onClick={testPulsing}>
             PULSE TEST
+          </button>
+          <button className="retro-button" onClick={handleSendClock}>
+            SEND CLOCK
           </button>
         </div>
       </div>

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -25,6 +25,7 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
 
   const clearPad = () => {
     setPadColour(pad.id, '#000000');
+    setPadLabel(pad.id, '');
     if (status === 'connected') {
       if (pad.note !== undefined) {
         send(noteOn(pad.note, 0, channel));

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -20,6 +20,7 @@ export default function SettingsModal({ onClose }: Props) {
   const pingOrange = useStore((s) => s.settings.pingOrange);
   const pingEnabled = useStore((s) => s.settings.pingEnabled);
   const clearBeforeLoad = useStore((s) => s.settings.clearBeforeLoad);
+  const clock = useStore((s) => s.settings.clock);
   const setHost = useStore((s) => s.setHost);
   const setPort = useStore((s) => s.setPort);
   const setAutoReconnect = useStore((s) => s.setAutoReconnect);
@@ -32,6 +33,7 @@ export default function SettingsModal({ onClose }: Props) {
   const setPingOrange = useStore((s) => s.setPingOrange);
   const setPingEnabled = useStore((s) => s.setPingEnabled);
   const setClearBeforeLoad = useStore((s) => s.setClearBeforeLoad);
+  const setClock = useStore((s) => s.setClock);
   const addToast = useToastStore((s) => s.addToast);
 
   const [h, setH] = useState(host);
@@ -46,6 +48,7 @@ export default function SettingsModal({ onClose }: Props) {
   const [po, setPo] = useState(pingOrange);
   const [pe, setPe] = useState(pingEnabled);
   const [cbl, setCbl] = useState(clearBeforeLoad);
+  const [clk, setClk] = useState(clock.join(' '));
   const fileRef = useRef<HTMLInputElement>(null);
 
   const save = () => {
@@ -61,6 +64,13 @@ export default function SettingsModal({ onClose }: Props) {
     setPingYellow(py);
     setPingOrange(po);
     setClearBeforeLoad(cbl);
+    setClock(
+      clk
+        .split(/\s+/)
+        .map((v) => parseInt(v, 10))
+        .filter((n) => !Number.isNaN(n))
+        .map((n) => Math.min(255, Math.max(0, n))),
+    );
     onClose();
     addToast('Settings saved', 'success');
   };
@@ -96,6 +106,7 @@ export default function SettingsModal({ onClose }: Props) {
         setPingYellow(cfg.pingYellow ?? py);
         setPingOrange(cfg.pingOrange ?? po);
         setClearBeforeLoad(cfg.clearBeforeLoad ?? cbl);
+        setClock(Array.isArray(cfg.clock) ? cfg.clock : clock);
         setH(cfg.host ?? h);
         setP(cfg.port ?? p);
         setAr(cfg.autoReconnect ?? ar);
@@ -108,6 +119,11 @@ export default function SettingsModal({ onClose }: Props) {
         setPo(cfg.pingOrange ?? po);
         setPe(cfg.pingEnabled ?? pe);
         setCbl(cfg.clearBeforeLoad ?? cbl);
+        setClk(
+          (Array.isArray(cfg.clock) ? cfg.clock : clock)
+            .map((n: number) => n.toString())
+            .join(' '),
+        );
         addToast('Config imported', 'success');
       } catch {
         addToast('Failed to import config', 'error');
@@ -269,6 +285,18 @@ export default function SettingsModal({ onClose }: Props) {
               >
                 CLEAR BEFORE LOAD
               </label>
+            </div>
+            <div className="mb-3">
+              <label className="form-label text-info">CLOCK MESSAGE:</label>
+              <input
+                className="form-control retro-input"
+                value={clk}
+                onChange={(e) => setClk(e.target.value)}
+                placeholder="248"
+              />
+              <small className="text-warning">
+                Space-separated decimal bytes
+              </small>
             </div>
             {ar && (
               <>

--- a/src/midiMessages.ts
+++ b/src/midiMessages.ts
@@ -95,6 +95,10 @@ export function setLedPulsing(id: number, color: number): number[] {
   return sysex(0x28, clamp7(id), clamp7(color));
 }
 
+export function midiClock(): number[] {
+  return [0xf8];
+}
+
 export function setLedRGB(
   id: number,
   red: number,

--- a/src/store.ts
+++ b/src/store.ts
@@ -75,6 +75,7 @@ interface SettingsSlice {
     pingOrange: number;
     pingEnabled: boolean;
     clearBeforeLoad: boolean;
+    clock: number[];
   };
   setHost: (h: string) => void;
   setPort: (p: number) => void;
@@ -88,6 +89,7 @@ interface SettingsSlice {
   setPingOrange: (ms: number) => void;
   setPingEnabled: (enabled: boolean) => void;
   setClearBeforeLoad: (enabled: boolean) => void;
+  setClock: (data: number[]) => void;
 }
 
 type StoreState = DevicesSlice &
@@ -157,6 +159,7 @@ export const useStore = create<StoreState>()(
         pingOrange: 250,
         pingEnabled: true,
         clearBeforeLoad: false,
+        clock: [0xf8],
       },
       setHost: (h) =>
         set((state) => ({ settings: { ...state.settings, host: h } })),
@@ -225,6 +228,10 @@ export const useStore = create<StoreState>()(
       setClearBeforeLoad: (enabled) =>
         set((state) => ({
           settings: { ...state.settings, clearBeforeLoad: enabled },
+        })),
+      setClock: (data) =>
+        set((state) => ({
+          settings: { ...state.settings, clock: data },
         })),
     }),
     {


### PR DESCRIPTION
## Summary
- clear labels when clearing pad colours
- support a system MIDI clock setting and send clock from toolbox
- choose clock message in system config

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b0f44d6c88325b11d66f1bda84684