### PR TITLE
Fix undefined clock state

### DIFF
--- a/src/LaunchpadControls.tsx
+++ b/src/LaunchpadControls.tsx
@@ -27,7 +27,7 @@ export default function LaunchpadControls() {
   const padChannels = useStore((s) => s.padChannels);
   const setPadColours = useStore((s) => s.setPadColours);
   const setPadChannels = useStore((s) => s.setPadChannels);
-  const clockBytes = useStore((s) => s.settings.clock);
+  const clockBytes = useStore((s) => s.settings.clock ?? [0xf8]);
   const addToast = useToastStore((s) => s.addToast);
   const notify = (ok: boolean, action: string) => {
     addToast(

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -20,7 +20,7 @@ export default function SettingsModal({ onClose }: Props) {
   const pingOrange = useStore((s) => s.settings.pingOrange);
   const pingEnabled = useStore((s) => s.settings.pingEnabled);
   const clearBeforeLoad = useStore((s) => s.settings.clearBeforeLoad);
-  const clock = useStore((s) => s.settings.clock);
+  const clock = useStore((s) => s.settings.clock ?? [0xf8]);
   const setHost = useStore((s) => s.setHost);
   const setPort = useStore((s) => s.setPort);
   const setAutoReconnect = useStore((s) => s.setAutoReconnect);

--- a/src/store.ts
+++ b/src/store.ts
@@ -237,6 +237,18 @@ export const useStore = create<StoreState>()(
     {
       name: 'store',
       storage: createJSONStorage(() => idbStorage),
+      merge: (persisted: unknown, current: StoreState): StoreState => {
+        const p = persisted as Partial<StoreState>;
+        return {
+          ...current,
+          ...p,
+          settings: {
+            ...current.settings,
+            ...p.settings,
+            clock: p.settings?.clock ?? current.settings.clock,
+          },
+        };
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- default to `[0xf8]` clock bytes in LaunchpadControls and SettingsModal
- merge persisted store state with defaults to ensure `clock` is set

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b169f139c832595827997841db531