### PR TITLE
Add per-pad LED mode buttons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 **automidi** is a Vite + React application that provides a simple interface for
 controlling MIDI devices. When a Launchpad X is detected the app automatically
-switches the controller into *Programmer* mode so that every pad can be
+switches the controller into _Programmer_ mode so that every pad can be
 addressed individually.
 
 ---
@@ -53,10 +53,13 @@ can be previewed locally using `npm run preview`.
   Programmer mode automatically.
 - Top and side pads are mapped to CC numbers while the main grid is mapped to
   notes, letting you experiment with lighting and macros.
-MIDI channels map LED behaviours:
-- **Channel 1** (`0x90`/`0xB0`) for static colours
-- **Channel 2** (`0x91`/`0xB1`) for flashing colours
-- **Channel 3** (`0x92`/`0xB2`) for pulsing colours
+  Color modes are chosen independently via the MIDI channel:
+  - **Channel 1** (`0x90`/`0xB0`) for static colours
+  - **Channel 2** (`0x91`/`0xB1`) for flashing colours
+  - **Channel 3** (`0x92`/`0xB2`) for pulsing colours
+  - Each pad's side panel now offers **STATIC**, **FLASH** and **PULSE**
+    buttons. Selecting a button sends the current colour on the
+    corresponding channel so modes can be mixed across the grid.
 
 ---
 

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -52,8 +52,7 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
     setPadLabel(pad.id, e.target.value);
   };
 
-  const handleChannelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const ch = Number(e.target.value);
+  const handleModeClick = (ch: number) => {
     setPadChannel(pad.id, ch);
     const colorVal =
       LAUNCHPAD_COLORS.find((c) => c.color === colour)?.value || 0;
@@ -93,15 +92,26 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
       </div>
       <div className="mb-3">
         <label className="form-label text-info">MODE:</label>
-        <select
-          className="form-select retro-select"
-          value={channel}
-          onChange={handleChannelChange}
-        >
-          <option value={1}>Static</option>
-          <option value={2}>Flashing</option>
-          <option value={3}>Pulsing</option>
-        </select>
+        <div className="mode-buttons d-flex">
+          <button
+            className={`retro-button btn-sm me-2${channel === 1 ? ' selected' : ''}`}
+            onClick={() => handleModeClick(1)}
+          >
+            STATIC
+          </button>
+          <button
+            className={`retro-button btn-sm me-2${channel === 2 ? ' selected' : ''}`}
+            onClick={() => handleModeClick(2)}
+          >
+            FLASH
+          </button>
+          <button
+            className={`retro-button btn-sm${channel === 3 ? ' selected' : ''}`}
+            onClick={() => handleModeClick(3)}
+          >
+            PULSE
+          </button>
+        </div>
       </div>
       <div className="mb-3">
         <label className="form-label text-info">LABEL:</label>

--- a/src/index.css
+++ b/src/index.css
@@ -193,6 +193,11 @@ body {
   box-shadow: 0 0 15px #00ffff;
 }
 
+.retro-button.selected {
+  background: #00ffff !important;
+  color: #000080 !important;
+}
+
 .retro-input {
   background: #000020 !important;
   border: 1px solid #00ff00 !important;


### PR DESCRIPTION
## Summary
- add STATIC, FLASH and PULSE buttons in the pad options panel
- send LED updates on mode selection
- highlight selected mode in CSS
- document per-pad mode buttons in README

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b13463cdc8325844ec0669d4c3b1b