### PR TITLE
Add per-mode pad colours

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,8 +57,8 @@ can be previewed locally using `npm run preview`.
   - **Channel 1** (`0x90`/`0xB0`) for static colours
   - **Channel 2** (`0x91`/`0xB1`) for flashing colours
   - **Channel 3** (`0x92`/`0xB2`) for pulsing colours
-  - Each pad's side panel now offers **STATIC**, **FLASH** and **PULSE**
-    buttons. Selecting a button sends the current colour on the
+  - Each pad's side panel now offers colour pickers for **STATIC**, **FLASH**
+    and **PULSE** modes. Selecting a mode button sends the chosen colour on the
     corresponding channel so modes can be mixed across the grid.
 
 ---

--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -68,16 +68,19 @@ export default function ConfigManager() {
       ok = send(clearAllLeds());
     }
     ok = send(enterProgrammerMode()) && ok;
-    for (const [id, hex] of Object.entries(cfg.padColours)) {
-      const color = LAUNCHPAD_COLORS.find((c) => c.color === hex)?.value;
-      if (color === undefined) continue;
-      const channel = cfg.padChannels?.[id] || 1;
-      if (id.startsWith('n-')) {
-        const note = Number(id.slice(2));
-        if (!Number.isNaN(note)) ok = send(noteOn(note, color, channel)) && ok;
-      } else if (id.startsWith('cc-')) {
-        const num = Number(id.slice(3));
-        if (!Number.isNaN(num)) ok = send(cc(num, color, channel)) && ok;
+    for (const [id, chMap] of Object.entries(cfg.padColours)) {
+      for (const [chStr, hex] of Object.entries(chMap)) {
+        const channel = Number(chStr);
+        const color = LAUNCHPAD_COLORS.find((c) => c.color === hex)?.value;
+        if (color === undefined) continue;
+        if (id.startsWith('n-')) {
+          const note = Number(id.slice(2));
+          if (!Number.isNaN(note))
+            ok = send(noteOn(note, color, channel)) && ok;
+        } else if (id.startsWith('cc-')) {
+          const num = Number(id.slice(3));
+          if (!Number.isNaN(num)) ok = send(cc(num, color, channel)) && ok;
+        }
       }
     }
     addToast(

--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -38,7 +38,8 @@ const Pad = memo(
     selected?: boolean;
     extraClass?: string;
   }) => {
-    const colour = useStore((s) => s.padColours[id] || '#000000');
+    const channel = useStore((s) => s.padChannels[id] || 1);
+    const colour = useStore((s) => s.padColours[id]?.[channel] || '#000000');
     const label = useStore((s) => s.padLabels[id] || '');
     const displayLabel = label.length > 6 ? `${label.slice(0, 5)}…` : label;
 

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export default function PadOptionsPanel({ pad, onClose }: Props) {
-  const colour = useStore((s) => s.padColours[pad.id] || '#000000');
+  const colours = useStore((s) => s.padColours[pad.id] || {});
   const label = useStore((s) => s.padLabels[pad.id] || '');
   const channel = useStore((s) => s.padChannels[pad.id] || 1);
   const setPadColour = useStore((s) => s.setPadColour);
@@ -24,7 +24,7 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
   const { send, status } = useMidi();
 
   const clearPad = () => {
-    setPadColour(pad.id, '#000000');
+    [1, 2, 3].forEach((ch) => setPadColour(pad.id, '#000000', ch));
     setPadLabel(pad.id, '');
     if (status === 'connected') {
       if (pad.note !== undefined) {
@@ -35,18 +35,19 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selected = LAUNCHPAD_COLORS.find((c) => c.color === e.target.value);
-    if (!selected) return;
-    setPadColour(pad.id, selected.color);
-    if (status === 'connected') {
-      if (pad.note !== undefined) {
-        send(noteOn(pad.note, selected.value, channel));
-      } else if (pad.cc !== undefined) {
-        send(cc(pad.cc, selected.value, channel));
+  const handleChange =
+    (ch: number) => (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const selected = LAUNCHPAD_COLORS.find((c) => c.color === e.target.value);
+      if (!selected) return;
+      setPadColour(pad.id, selected.color, ch);
+      if (status === 'connected') {
+        if (pad.note !== undefined) {
+          send(noteOn(pad.note, selected.value, ch));
+        } else if (pad.cc !== undefined) {
+          send(cc(pad.cc, selected.value, ch));
+        }
       }
-    }
-  };
+    };
 
   const handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPadLabel(pad.id, e.target.value);
@@ -54,8 +55,9 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
 
   const handleModeClick = (ch: number) => {
     setPadChannel(pad.id, ch);
+    const colorHex = colours[ch] || '#000000';
     const colorVal =
-      LAUNCHPAD_COLORS.find((c) => c.color === colour)?.value || 0;
+      LAUNCHPAD_COLORS.find((c) => c.color === colorHex)?.value || 0;
     if (status === 'connected') {
       if (pad.note !== undefined) {
         send(noteOn(pad.note, colorVal, ch));
@@ -69,12 +71,56 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
     <div className="pad-options-panel" onClick={(e) => e.stopPropagation()}>
       <h4>PAD {pad.id}</h4>
       <div className="mb-3">
-        <label className="form-label text-info">COLOR:</label>
+        <label className="form-label text-info">STATIC COLOR:</label>
         <select
           className="form-select retro-select"
-          value={colour}
-          onChange={handleChange}
-          style={{ backgroundColor: colour }}
+          value={colours[1] || '#000000'}
+          onChange={handleChange(1)}
+          style={{ backgroundColor: colours[1] || '#000000' }}
+        >
+          {LAUNCHPAD_COLORS.map((color) => (
+            <option
+              key={color.value}
+              value={color.color}
+              style={{
+                backgroundColor: color.color,
+                color: color.color === '#000000' ? '#fff' : '#000',
+              }}
+            >
+              {color.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-3">
+        <label className="form-label text-info">FLASH COLOR:</label>
+        <select
+          className="form-select retro-select"
+          value={colours[2] || '#000000'}
+          onChange={handleChange(2)}
+          style={{ backgroundColor: colours[2] || '#000000' }}
+        >
+          {LAUNCHPAD_COLORS.map((color) => (
+            <option
+              key={color.value}
+              value={color.color}
+              style={{
+                backgroundColor: color.color,
+                color: color.color === '#000000' ? '#fff' : '#000',
+              }}
+            >
+              {color.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-3">
+        <label className="form-label text-info">PULSE COLOR:</label>
+        <select
+          className="form-select retro-select"
+          value={colours[3] || '#000000'}
+          onChange={handleChange(3)}
+          style={{ backgroundColor: colours[3] || '#000000' }}
         >
           {LAUNCHPAD_COLORS.map((color) => (
             <option


### PR DESCRIPTION
## Summary
- enable independent colours for static, flash and pulse modes
- update Launchpad UI to support per-mode colours
- propagate mode colours when loading configs or sending to Launchpad
- migrate persisted pad colour state

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b19f148c08325972fa55adbf13409