### PR TITLE
Fix infinite render in PadOptionsPanel

### DIFF
--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -15,7 +15,8 @@ interface Props {
 }
 
 export default function PadOptionsPanel({ pad, onClose }: Props) {
-  const colours = useStore((s) => s.padColours[pad.id] || {});
+  const storeColours = useStore((s) => s.padColours[pad.id]);
+  const colours = storeColours || {};
   const label = useStore((s) => s.padLabels[pad.id] || '');
   const channel = useStore((s) => s.padChannels[pad.id] || 1);
   const setPadColour = useStore((s) => s.setPadColour);


### PR DESCRIPTION
## Summary
- avoid returning a new object each time PadOptionsPanel reads pad colours

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b1de89174832585b2e47ad2348faf