### PR TITLE
Update pad UI to reflect mode

### DIFF
--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -39,7 +39,10 @@ const Pad = memo(
     extraClass?: string;
   }) => {
     const channel = useStore((s) => s.padChannels[id] || 1);
-    const colour = useStore((s) => s.padColours[id]?.[channel] || '#000000');
+    const colours = useStore((s) => s.padColours[id] || {});
+    const staticColour = colours[1] || '#000000';
+    const flashColour = colours[2] || staticColour;
+    const pulseColour = colours[3] || '#000000';
     const label = useStore((s) => s.padLabels[id] || '');
     const displayLabel = label.length > 6 ? `${label.slice(0, 5)}…` : label;
 
@@ -51,9 +54,16 @@ const Pad = memo(
       <div
         className={`midi-pad-container ${selected ? 'selected' : ''} ${
           extraClass || ''
-        }`}
+        } ${channel === 2 ? 'flash' : ''} ${channel === 3 ? 'pulse' : ''}`}
         id={id}
-        style={{ backgroundColor: colour }}
+        style={
+          {
+            backgroundColor: channel === 3 ? pulseColour : staticColour,
+            '--static-color': staticColour,
+            '--flash-color': flashColour,
+            '--pulse-color': pulseColour,
+          } as React.CSSProperties
+        }
         title={note !== undefined ? `Note ${note}` : `CC ${ccNum}`}
         onClick={() => onSelect({ id, note, cc: ccNum })}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -73,6 +73,27 @@ body {
   }
 }
 
+@keyframes pad-flash {
+  0%,
+  49% {
+    background-color: var(--static-color);
+  }
+  50%,
+  100% {
+    background-color: var(--flash-color);
+  }
+}
+
+@keyframes pad-pulse {
+  0%,
+  100% {
+    filter: brightness(0.6);
+  }
+  50% {
+    filter: brightness(1.2);
+  }
+}
+
 .status-bar {
   background: #000040;
   border: 1px solid #00ff00;
@@ -133,6 +154,15 @@ body {
 .midi-pad-container:hover {
   border-color: #ffff00;
   box-shadow: 0 0 10px #ffff00;
+}
+
+.midi-pad-container.flash {
+  animation: pad-flash 1s steps(2, start) infinite;
+}
+
+.midi-pad-container.pulse {
+  animation: pad-pulse 1s infinite;
+  background-color: var(--pulse-color);
 }
 
 .midi-pad-empty {


### PR DESCRIPTION
## Summary
- show Launchpad pad animations for flash and pulse modes
- add CSS for `pad-flash` and `pad-pulse` animations

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: several TS2307 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b2b9ae2288325b049a78b3e97ac29