### PR TITLE
Add pad event actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,11 @@ import ActionBar from './ActionBar';
 import FloatingActionBar from './FloatingActionBar';
 import ConfigManager from './ConfigManager';
 import ToastContainer from './ToastContainer';
+import { usePadActions } from './usePadActions';
 import './App.css';
 
 function App() {
+  usePadActions();
   return (
     <div className="App">
       <div className="scan-lines"></div>

--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -20,7 +20,9 @@ export default function ConfigManager() {
   const padColours = useStore((s) => s.padColours);
   const padLabels = useStore((s) => s.padLabels);
   const padChannels = useStore((s) => s.padChannels);
+  const padActions = useStore((s) => s.padActions);
   const setPadChannels = useStore((s) => s.setPadChannels);
+  const setPadActions = useStore((s) => s.setPadActions);
   const clearBeforeLoad = useStore((s) => s.settings.clearBeforeLoad);
   const sysexColorMode = useStore((s) => s.settings.sysexColorMode);
   const updateConfig = useStore((s) => s.updateConfig);
@@ -39,6 +41,7 @@ export default function ConfigManager() {
       padColours,
       padLabels,
       padChannels,
+      padActions,
     };
     addConfig(cfg);
     setName('');
@@ -49,6 +52,7 @@ export default function ConfigManager() {
     setPadColours(cfg.padColours);
     if (cfg.padLabels) setPadLabels(cfg.padLabels);
     if (cfg.padChannels) setPadChannels(cfg.padChannels);
+    if (cfg.padActions) setPadActions(cfg.padActions);
     addToast('Config loaded', 'success');
   };
 
@@ -65,7 +69,7 @@ export default function ConfigManager() {
   };
 
   const saveToConfig = (cfg: PadConfig) => {
-    updateConfig({ ...cfg, padColours, padLabels, padChannels });
+    updateConfig({ ...cfg, padColours, padLabels, padChannels, padActions });
     addToast('Config updated', 'success');
   };
 
@@ -134,6 +138,7 @@ export default function ConfigManager() {
           id: Date.now().toString(),
           padLabels: cfg.padLabels || {},
           padChannels: cfg.padChannels || {},
+          padActions: cfg.padActions || {},
         });
         addToast('Config imported', 'success');
       } catch {

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -19,10 +19,13 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
   const colours = storeColours || {};
   const label = useStore((s) => s.padLabels[pad.id] || '');
   const channel = useStore((s) => s.padChannels[pad.id] || 1);
+  const action = useStore((s) => s.padActions[pad.id] || {});
   const sysexColorMode = useStore((s) => s.settings.sysexColorMode);
   const setPadColour = useStore((s) => s.setPadColour);
   const setPadLabel = useStore((s) => s.setPadLabel);
   const setPadChannel = useStore((s) => s.setPadChannel);
+  const setPadAction = useStore((s) => s.setPadAction);
+  const macros = useStore((s) => s.macros);
   const { send, status } = useMidi();
 
   const clearPad = () => {
@@ -66,6 +69,12 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
   const handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPadLabel(pad.id, e.target.value);
   };
+
+  const handleActionChange =
+    (type: 'noteOn' | 'noteOff') =>
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setPadAction(pad.id, { ...action, [type]: e.target.value || undefined });
+    };
 
   const handleModeClick = (ch: number) => {
     setPadChannel(pad.id, ch);
@@ -188,6 +197,36 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
           onChange={handleLabelChange}
           placeholder="Label"
         />
+      </div>
+      <div className="mb-3">
+        <label className="form-label text-info">ON NOTE ON:</label>
+        <select
+          className="form-select retro-select"
+          value={action.noteOn || ''}
+          onChange={handleActionChange('noteOn')}
+        >
+          <option value="">NONE</option>
+          {macros.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-3">
+        <label className="form-label text-info">ON NOTE OFF:</label>
+        <select
+          className="form-select retro-select"
+          value={action.noteOff || ''}
+          onChange={handleActionChange('noteOff')}
+        >
+          <option value="">NONE</option>
+          {macros.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
       </div>
       <button className="retro-button me-2" onClick={clearPad}>
         CLEAR

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,16 +36,24 @@ interface MacrosSlice {
 
 export type PadColourMap = Record<number, string>;
 
+export interface PadActions {
+  noteOn?: string;
+  noteOff?: string;
+}
+
 interface PadsSlice {
   padColours: Record<string, PadColourMap>;
   padLabels: Record<string, string>;
   padChannels: Record<string, number>;
+  padActions: Record<string, PadActions>;
   setPadColour: (id: string, colour: string, channel: number) => void;
   setPadColours: (colours: Record<string, PadColourMap>) => void;
   setPadLabel: (id: string, label: string) => void;
   setPadLabels: (labels: Record<string, string>) => void;
   setPadChannel: (id: string, channel: number) => void;
   setPadChannels: (channels: Record<string, number>) => void;
+  setPadAction: (id: string, actions: PadActions) => void;
+  setPadActions: (actions: Record<string, PadActions>) => void;
 }
 
 export interface PadConfig {
@@ -54,6 +62,7 @@ export interface PadConfig {
   padColours: Record<string, PadColourMap>;
   padLabels?: Record<string, string>;
   padChannels?: Record<string, number>;
+  padActions?: Record<string, PadActions>;
 }
 
 interface ConfigsSlice {
@@ -130,6 +139,7 @@ export const useStore = create<StoreState>()(
       padColours: {},
       padLabels: {},
       padChannels: {},
+      padActions: {},
       setPadColour: (id, colour, channel) =>
         set((state) => ({
           padColours: {
@@ -147,6 +157,11 @@ export const useStore = create<StoreState>()(
         })),
       setPadChannels: (channels) =>
         set(() => ({ padChannels: { ...channels } })),
+      setPadAction: (id, actions) =>
+        set((state) => ({
+          padActions: { ...state.padActions, [id]: actions },
+        })),
+      setPadActions: (actions) => set(() => ({ padActions: { ...actions } })),
       configs: [],
       addConfig: (c) => set((s) => ({ configs: [...s.configs, c] })),
       updateConfig: (c) =>

--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useMidi, type MidiMessage } from './useMidi';
+import { useStore } from './store';
+import { useMacroPlayer } from './useMacroPlayer';
+
+export function usePadActions() {
+  const padActions = useStore((s) => s.padActions);
+  const { listen } = useMidi();
+  const { playMacro } = useMacroPlayer();
+
+  useEffect(() => {
+    const handler = (msg: MidiMessage) => {
+      const bytes = msg.message;
+      if (!bytes || bytes.length < 2) return;
+      const status = bytes[0] & 0xf0;
+      const channel = bytes[0] & 0x0f;
+      let padId: string | null = null;
+      let isOn = false;
+
+      if (status === 0x90) {
+        padId = `n-${bytes[1]}`;
+        isOn = bytes[2] !== 0;
+      } else if (status === 0x80) {
+        padId = `n-${bytes[1]}`;
+        isOn = false;
+      } else if (status === 0xb0) {
+        padId = `cc-${bytes[1]}`;
+        isOn = bytes[2] !== 0;
+      } else {
+        return;
+      }
+
+      const action = padActions[padId];
+      if (!action) return;
+      if (isOn && action.noteOn) {
+        playMacro(action.noteOn);
+      } else if (!isOn && action.noteOff) {
+        playMacro(action.noteOff);
+      }
+    };
+
+    const unlisten = listen(handler);
+    return () => unlisten();
+  }, [listen, playMacro, padActions]);
+}


### PR DESCRIPTION
## Summary
- implement per-pad event actions in store
- save and load pad action configs
- provide note on/off macro selection in PadOptionsPanel
- listen for incoming messages and trigger actions

## Testing
- `npx prettier --write src/store.ts src/PadOptionsPanel.tsx src/ConfigManager.tsx src/usePadActions.ts src/App.tsx`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686b2bd838e08325915ed34eace9b05b