### PR TITLE
Implement OS notifications and MIDI pulse confirm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@tonejs/midi": "^2.0.28",
+        "cors": "^2.8.5",
         "express": "^4.21.2",
         "idb-keyval": "^6.2.2",
         "immer": "^10.1.1",
         "jzz": "^1.9.3",
         "node-key-sender": "^1.0.11",
+        "node-notifier": "^10.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "vite-plugin-pwa": "^1.0.1",
@@ -3776,6 +3778,19 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -4999,6 +5014,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5345,6 +5366,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5633,6 +5669,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5643,7 +5691,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jake": {
@@ -6053,11 +6100,46 @@
       "integrity": "sha512-vv2IXd8QdZBFYXaIy02uy2rK6EKj+tOTEuoTxJKS9l8zw8Cz6DeLffR8ompj7N2A3h6XK7aiy+YAcTaeOqwp2Q==",
       "license": "MIT"
     },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/node-notifier/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -6984,6 +7066,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "license": "MIT"
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -7761,6 +7849,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7950,7 +8047,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "webmidi": "^3.1.12",
     "ws": "^8.18.3",
     "zustand": "^5.0.6",
-    "node-key-sender": "^1.0.11"
+    "node-key-sender": "^1.0.11",
+    "node-notifier": "^10.0.1",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -2,9 +2,12 @@ const express = require('express');
 const { WebSocketServer } = require('ws');
 const { WebMidi } = require('webmidi');
 const keySender = require('node-key-sender');
+const notifier = require('node-notifier');
+const cors = require('cors');
 
 const app = express();
 app.use(express.json());
+app.use(cors());
 
 let currentDevices = { inputs: [], outputs: [] };
 
@@ -55,6 +58,18 @@ WebMidi.enable({ sysex: true })
         console.error('MIDI send error:', err);
         res.status(500).json({ error: err.message });
       }
+    });
+
+    app.post('/notify', (req, res) => {
+      const { title = 'Automidi', message } = req.body || {};
+      if (!message) {
+        res.status(400).json({ error: 'message is required' });
+        return;
+      }
+      notifier.notify({ title, message }, (err) => {
+        if (err) console.error('Notification error:', err);
+      });
+      res.json({ ok: true });
     });
 
     app.post('/keys/type', async (req, res) => {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,22 +1,18 @@
 import { useToastStore } from './toastStore';
+import { useStore } from './store';
 
-export function notify(message: string) {
+export async function notify(message: string) {
   const addToast = useToastStore.getState().addToast;
-  if (typeof window !== 'undefined' && 'Notification' in window) {
-    if (Notification.permission === 'granted') {
-      new Notification(message);
-    } else if (Notification.permission === 'default') {
-      Notification.requestPermission().then((perm) => {
-        if (perm === 'granted') {
-          new Notification(message);
-        } else {
-          addToast(message, 'success');
-        }
-      });
-    } else {
-      addToast(message, 'success');
-    }
-  } else {
+  const { host, port } = useStore.getState().settings;
+  try {
+    const res = await fetch(`http://${host}:${port}/notify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    });
+    if (!res.ok) throw new Error('Request failed');
+  } catch (err) {
+    console.error('OS notification failed:', err);
     addToast(message, 'success');
   }
 }

--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -3,16 +3,42 @@ import { useMidi, type MidiMessage } from './useMidi';
 import { useStore } from './store';
 import { useKeyMacroPlayer } from './useKeyMacroPlayer';
 import { notify } from './notify';
+import LAUNCHPAD_COLORS from './launchpadColors';
+import { noteOn, cc, lightingSysEx } from './midiMessages';
 
 export function usePadActions() {
   const padActions = useStore((s) => s.padActions);
   const padChannels = useStore((s) => s.padChannels);
+  const padColours = useStore((s) => s.padColours);
+  const sysexColorMode = useStore((s) => s.settings.sysexColorMode);
   const setPadChannel = useStore((s) => s.setPadChannel);
-  const { listen } = useMidi();
+  const { listen, send } = useMidi();
   const { playMacro } = useKeyMacroPlayer();
   const confirmRef = useRef<
     Record<string, { t: ReturnType<typeof setTimeout>; prev: number }>
   >({});
+
+  const sendPadState = (id: string, channel: number) => {
+    const colours = padColours[id] || {};
+    const colorHex = colours[channel] || colours[1] || '#000000';
+    const colorVal =
+      LAUNCHPAD_COLORS.find((c) => c.color === colorHex)?.value || 0;
+    const padId = id.startsWith('n-')
+      ? Number(id.slice(2))
+      : id.startsWith('cc-')
+        ? Number(id.slice(3))
+        : NaN;
+    if (Number.isNaN(padId)) return;
+    if (sysexColorMode) {
+      const type = channel === 1 ? 0 : channel === 2 ? 1 : 2;
+      const data = channel === 2 ? [0, colorVal] : [colorVal];
+      send(lightingSysEx([{ type, index: padId, data }]));
+    } else if (id.startsWith('n-')) {
+      send(noteOn(padId, colorVal, channel));
+    } else {
+      send(cc(padId, colorVal, channel));
+    }
+  };
 
   const handleMacro = (macroId: string, id: string, confirm?: boolean) => {
     if (!confirm) {
@@ -23,15 +49,18 @@ export function usePadActions() {
     if (!entry) {
       const prev = padChannels[id] || 1;
       setPadChannel(id, 3);
+      sendPadState(id, 3);
       notify('Press pad again to confirm');
       const t = setTimeout(() => {
         setPadChannel(id, prev);
+        sendPadState(id, prev);
         delete confirmRef.current[id];
       }, 2000);
       confirmRef.current[id] = { t, prev };
     } else {
       clearTimeout(entry.t);
       setPadChannel(id, entry.prev);
+      sendPadState(id, entry.prev);
       delete confirmRef.current[id];
       playMacro(macroId);
     }


### PR DESCRIPTION
## Summary
- add `node-notifier` and `cors` dependencies
- enable CORS and OS notifications in Node server
- update `notify` to use server endpoint instead of browser notifications
- send MIDI messages when pads enter/exit confirm state

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b41472d588325b21f85e99a3605a6