### PR TITLE
Enhance macro functionality

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -4,6 +4,7 @@ const { WebMidi } = require('webmidi');
 const keySender = require('node-key-sender');
 const notifier = require('node-notifier');
 const cors = require('cors');
+const { exec } = require('child_process');
 
 const app = express();
 app.use(express.json());
@@ -90,6 +91,38 @@ WebMidi.enable({ sysex: true })
         console.error('Key send error:', err);
         res.status(500).json({ error: err.message });
       }
+    });
+
+    app.post('/run/app', (req, res) => {
+      const { app: appPath } = req.body || {};
+      if (!appPath) {
+        res.status(400).json({ error: 'app path required' });
+        return;
+      }
+      exec(`"${appPath}"`, (err) => {
+        if (err) {
+          console.error('App exec error:', err);
+          res.status(500).json({ error: err.message });
+        } else {
+          res.json({ ok: true });
+        }
+      });
+    });
+
+    app.post('/run/shell', (req, res) => {
+      const { cmd } = req.body || {};
+      if (!cmd) {
+        res.status(400).json({ error: 'cmd required' });
+        return;
+      }
+      exec(cmd, (err) => {
+        if (err) {
+          console.error('Shell exec error:', err);
+          res.status(500).json({ error: err.message });
+        } else {
+          res.json({ ok: true });
+        }
+      });
     });
 
     const server = app.listen(process.env.PORT || 3000, () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,14 +44,10 @@ function App() {
           <div className="row">
             <div className="col-md-6">
               <MacroList />
+              <MacroBuilder />
             </div>
             <div className="col-md-6">
               <SysexWorkbench />
-            </div>
-          </div>
-          <div className="row">
-            <div className="col-12">
-              <MacroBuilder />
             </div>
           </div>
         </div>

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -1,12 +1,56 @@
 import { useKeyMacroPlayer } from './useKeyMacroPlayer';
-import { useStore } from './store';
+import { useStore, type Macro } from './store';
 import { useToastStore } from './toastStore';
+import { useState } from 'react';
 
 export default function MacroList() {
   const macros = useStore((s) => s.macros);
   const removeMacro = useStore((s) => s.removeMacro);
+  const updateMacro = useStore((s) => s.updateMacro);
   const addToast = useToastStore((s) => s.addToast);
   const { playMacro } = useKeyMacroPlayer();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [sequence, setSequence] = useState('');
+  const [interval, setInterval] = useState(50);
+  const [type, setType] = useState<'keys' | 'app' | 'shell'>('keys');
+  const [command, setCommand] = useState('');
+  const [nextId, setNextId] = useState('');
+
+  const startEdit = (id: string) => {
+    const m = macros.find((x) => x.id === id);
+    if (!m) return;
+    setEditingId(id);
+    setName(m.name);
+    setSequence(m.sequence?.join(' ') || '');
+    setInterval(m.interval ?? 50);
+    setType(m.type || 'keys');
+    setCommand(m.command || '');
+    setNextId(m.nextId || '');
+  };
+
+  const saveEdit = () => {
+    if (!editingId) return;
+    const m: Macro = { id: editingId, name: name.trim(), type };
+    if (nextId) m.nextId = nextId;
+    if (type === 'keys') {
+      const keys = sequence
+        .split(/\s+/)
+        .map((k) => k.trim())
+        .filter(Boolean);
+      if (keys.length === 0) return;
+      m.sequence = keys;
+      m.interval = Math.max(0, interval);
+    } else {
+      if (!command.trim()) return;
+      m.command = command.trim();
+    }
+    updateMacro(m);
+    addToast('Macro updated', 'success');
+    setEditingId(null);
+  };
+
+  const cancelEdit = () => setEditingId(null);
 
   return (
     <div className="retro-panel">
@@ -17,27 +61,108 @@ export default function MacroList() {
         <div>
           {macros.map((m) => (
             <div key={m.id} className="macro-list-item">
-              <span className="macro-name">{m.name}</span>
-              <div>
-                <button
-                  className="retro-button btn-sm me-1"
-                  onClick={() => playMacro(m.id)}
-                >
-                  PLAY
-                </button>
-                <span className="ms-2 text-info">
-                  {m.sequence.join(' ')} ({m.interval}ms)
-                </span>
-                <button
-                  className="retro-button btn-sm"
-                  onClick={() => {
-                    removeMacro(m.id);
-                    addToast('Macro deleted', 'success');
-                  }}
-                >
-                  DEL
-                </button>
-              </div>
+              {editingId === m.id ? (
+                <div className="w-100">
+                  <div className="d-flex flex-wrap mb-1">
+                    <input
+                      className="form-control retro-input me-2 mb-1"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                    />
+                    <select
+                      className="form-control retro-input me-2 mb-1"
+                      value={type}
+                      onChange={(e) =>
+                        setType(e.target.value as 'keys' | 'app' | 'shell')
+                      }
+                    >
+                      <option value="keys">Keys</option>
+                      <option value="app">Application</option>
+                      <option value="shell">Shell</option>
+                    </select>
+                    {type === 'keys' ? (
+                      <>
+                        <input
+                          className="form-control retro-input me-2 mb-1"
+                          value={sequence}
+                          onChange={(e) => setSequence(e.target.value)}
+                        />
+                        <input
+                          type="number"
+                          className="form-control retro-input me-2 mb-1"
+                          style={{ width: '80px' }}
+                          value={interval}
+                          onChange={(e) => setInterval(Number(e.target.value))}
+                        />
+                      </>
+                    ) : (
+                      <input
+                        className="form-control retro-input me-2 mb-1"
+                        value={command}
+                        onChange={(e) => setCommand(e.target.value)}
+                      />
+                    )}
+                    <select
+                      className="form-control retro-input me-2 mb-1"
+                      value={nextId}
+                      onChange={(e) => setNextId(e.target.value)}
+                    >
+                      <option value="">-- next macro --</option>
+                      {macros.map((o) => (
+                        <option key={o.id} value={o.id}>
+                          {o.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <button
+                      className="retro-button btn-sm me-1"
+                      onClick={saveEdit}
+                    >
+                      SAVE
+                    </button>
+                    <button
+                      className="retro-button btn-sm"
+                      onClick={cancelEdit}
+                    >
+                      CANCEL
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <span className="macro-name">{m.name}</span>
+                  <div>
+                    <button
+                      className="retro-button btn-sm me-1"
+                      onClick={() => playMacro(m.id)}
+                    >
+                      PLAY
+                    </button>
+                    <span className="ms-2 text-info">
+                      {m.type === 'keys'
+                        ? `${m.sequence?.join(' ')} (${m.interval}ms)`
+                        : m.command}
+                    </span>
+                    <button
+                      className="retro-button btn-sm ms-1"
+                      onClick={() => startEdit(m.id)}
+                    >
+                      EDIT
+                    </button>
+                    <button
+                      className="retro-button btn-sm ms-1"
+                      onClick={() => {
+                        removeMacro(m.id);
+                        addToast('Macro deleted', 'success');
+                      }}
+                    >
+                      DEL
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,8 +10,11 @@ import {
 export interface Macro {
   id: string;
   name: string;
-  sequence: string[];
-  interval: number;
+  sequence?: string[];
+  interval?: number;
+  type?: 'keys' | 'app' | 'shell';
+  command?: string;
+  nextId?: string;
 }
 
 interface DevicesSlice {

--- a/src/toastStore.ts
+++ b/src/toastStore.ts
@@ -18,7 +18,12 @@ export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
   addToast: (message, type) => {
     const id = Date.now() + Math.random();
-    set((state) => ({ toasts: [...state.toasts, { id, message, type }] }));
+    set((state) => {
+      if (state.toasts.length >= 5) {
+        return { toasts: state.toasts };
+      }
+      return { toasts: [...state.toasts, { id, message, type }] };
+    });
     setTimeout(() => {
       set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
     }, 4000);

--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -9,14 +9,31 @@ export function useKeyMacroPlayer() {
       const macro = macros.find((m) => m.id === macroId);
       if (!macro) return;
       try {
-        await fetch('/keys/type', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            sequence: macro.sequence,
-            interval: macro.interval,
-          }),
-        });
+        if (macro.type === 'app') {
+          await fetch('/run/app', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ app: macro.command }),
+          });
+        } else if (macro.type === 'shell') {
+          await fetch('/run/shell', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cmd: macro.command }),
+          });
+        } else {
+          await fetch('/keys/type', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              sequence: macro.sequence,
+              interval: macro.interval,
+            }),
+          });
+        }
+        if (macro.nextId) {
+          await playMacro(macro.nextId);
+        }
       } catch (err) {
         console.error('Failed to play macro', err);
       }


### PR DESCRIPTION
## Summary
- limit concurrent toasts to avoid spam
- move Macro Builder below Macro Sequencer
- add ability to run apps or shell commands
- enable macro editing and chaining

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b45e04960832593bb8da1c350f45c