### PR TITLE
Implement UI enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "immer": "^10.1.1",
         "jzz": "^1.9.3",
         "node-key-sender": "^1.0.11",
-        "node-notifier": "^10.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "toasted-notifier": "^10.1.0",
         "vite-plugin-pwa": "^1.0.1",
         "vite-plugin-svgr": "^4.3.0",
         "webmidi": "^3.1.12",
@@ -6100,32 +6100,6 @@
       "integrity": "sha512-vv2IXd8QdZBFYXaIy02uy2rK6EKj+tOTEuoTxJKS9l8zw8Cz6DeLffR8ompj7N2A3h6XK7aiy+YAcTaeOqwp2Q==",
       "license": "MIT"
     },
-    "node_modules/node-notifier": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
-      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "growly": "^1.3.0",
-        "is-wsl": "^2.2.0",
-        "semver": "^7.3.5",
-        "shellwords": "^0.1.1",
-        "uuid": "^8.3.2",
-        "which": "^2.0.2"
-      }
-    },
-    "node_modules/node-notifier/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7506,6 +7480,37 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toasted-notifier": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/toasted-notifier/-/toasted-notifier-10.1.0.tgz",
+      "integrity": "sha512-SvAufC4t75lRqwQtComPeDC93j8Toy3BRsD1cMIZ+YdfxTnIyxQb+YCuhXohNFDGJPI+RgOYImkDX76fTo1YDA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/aetherinox"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.7.2",
+        "shellwords": "^0.1.1",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/toasted-notifier/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -7847,15 +7852,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ws": "^8.18.3",
     "zustand": "^5.0.6",
     "node-key-sender": "^1.0.11",
-    "node-notifier": "^10.0.1",
+    "toasted-notifier": "^10.1.0",
     "cors": "^2.8.5"
   },
   "devDependencies": {

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -2,7 +2,7 @@ const express = require('express');
 const { WebSocketServer } = require('ws');
 const { WebMidi } = require('webmidi');
 const keySender = require('node-key-sender');
-const notifier = require('node-notifier');
+const notifier = require('toasted-notifier');
 const cors = require('cors');
 const { exec } = require('child_process');
 
@@ -63,6 +63,7 @@ WebMidi.enable({ sysex: true })
 
     app.post('/notify', (req, res) => {
       const { title = 'Automidi', message } = req.body || {};
+      console.log('Notify request:', title, message);
       if (!message) {
         res.status(400).json({ error: 'message is required' });
         return;
@@ -75,6 +76,7 @@ WebMidi.enable({ sysex: true })
 
     app.post('/keys/type', async (req, res) => {
       const { sequence = [], interval = 50 } = req.body || {};
+      console.log('Keys type request:', sequence, interval);
       if (!Array.isArray(sequence)) {
         res.status(400).json({ error: 'sequence must be an array of keys' });
         return;
@@ -95,6 +97,7 @@ WebMidi.enable({ sysex: true })
 
     app.post('/run/app', (req, res) => {
       const { app: appPath } = req.body || {};
+      console.log('Run app request:', appPath);
       if (!appPath) {
         res.status(400).json({ error: 'app path required' });
         return;
@@ -111,6 +114,7 @@ WebMidi.enable({ sysex: true })
 
     app.post('/run/shell', (req, res) => {
       const { cmd } = req.body || {};
+      console.log('Run shell request:', cmd);
       if (!cmd) {
         res.status(400).json({ error: 'cmd required' });
         return;

--- a/src/LaunchpadControls.tsx
+++ b/src/LaunchpadControls.tsx
@@ -143,136 +143,162 @@ export default function LaunchpadControls() {
     notify(send(bytes), 'Clock');
   };
 
+  const [showMore, setShowMore] = useState(false);
+
   return (
     <div className="retro-panel">
       <h3>◄ Launchpad Toolbox Matrix ►</h3>
+      <div className="mb-3">
+        <button className="retro-button me-2" onClick={handleClearAll}>
+          CLEAR ALL
+        </button>
+        <button className="retro-button me-2" onClick={handleClearConfig}>
+          CLEAR CONFIG
+        </button>
+        <button className="retro-button me-2" onClick={handleLoadToLaunchpad}>
+          LOAD INTO LAUNCHPAD
+        </button>
+        <button
+          className="retro-button btn-sm"
+          onClick={() => setShowMore(!showMore)}
+        >
+          {showMore ? 'LESS' : 'MORE'}
+        </button>
+      </div>
+      {showMore && (
+        <div className="row mb-3">
+          <div className="col-md-4">
+            <h5 className="text-info">MODE CONTROL:</h5>
+            <button
+              className="retro-button me-2 mb-2"
+              onClick={handleEnterProgrammer}
+            >
+              PROGRAMMER MODE
+            </button>
+            <button
+              className="retro-button me-2 mb-2"
+              onClick={handleExitProgrammer}
+            >
+              LIVE MODE
+            </button>
+            <div className="mb-2">
+              <label className="form-label text-info">LAYOUT:</label>
+              <div className="d-flex align-items-center">
+                <select
+                  className="form-select retro-select me-2"
+                  value={layout}
+                  onChange={(e) => setLayoutValue(Number(e.target.value))}
+                  style={{ width: 'auto' }}
+                >
+                  <option value={0}>Session</option>
+                  <option value={1}>Note</option>
+                  <option value={2}>Custom</option>
+                  <option value={3}>DAW Faders</option>
+                  <option value={4}>Programmer</option>
+                </select>
+                <button
+                  className="retro-button btn-sm"
+                  onClick={handleSetLayout}
+                >
+                  SET
+                </button>
+              </div>
+            </div>
+            <div className="mb-2">
+              <label className="form-label text-info">DAW BANK:</label>
+              <div className="d-flex align-items-center">
+                <input
+                  type="number"
+                  className="form-control retro-input me-2"
+                  style={{ width: '80px' }}
+                  min="0"
+                  max="7"
+                  value={dawBank}
+                  onChange={(e) => setDawBank(Number(e.target.value))}
+                />
+                <button className="retro-button btn-sm" onClick={handleSetDAW}>
+                  SET
+                </button>
+              </div>
+            </div>
+          </div>
 
-      <div className="row mb-3">
-        <div className="col-md-4">
-          <h5 className="text-info">MODE CONTROL:</h5>
-          <button
-            className="retro-button me-2 mb-2"
-            onClick={handleEnterProgrammer}
-          >
-            PROGRAMMER MODE
-          </button>
-          <button
-            className="retro-button me-2 mb-2"
-            onClick={handleExitProgrammer}
-          >
-            LIVE MODE
-          </button>
-          <div className="mb-2">
-            <label className="form-label text-info">LAYOUT:</label>
-            <div className="d-flex align-items-center">
-              <select
-                className="form-select retro-select me-2"
-                value={layout}
-                onChange={(e) => setLayoutValue(Number(e.target.value))}
-                style={{ width: 'auto' }}
-              >
-                <option value={0}>Session</option>
-                <option value={1}>Note</option>
-                <option value={2}>Custom</option>
-                <option value={3}>DAW Faders</option>
-                <option value={4}>Programmer</option>
-              </select>
-              <button className="retro-button btn-sm" onClick={handleSetLayout}>
-                SET
-              </button>
+          <div className="col-md-4">
+            <h5 className="text-info">LED CONTROL:</h5>
+            <div className="mb-3">
+              <label className="form-label text-info">BRIGHTNESS:</label>
+              <div className="d-flex align-items-center">
+                <input
+                  type="range"
+                  className="form-range me-2"
+                  min="0"
+                  max="127"
+                  value={brightness}
+                  onChange={(e) => setBrightnessValue(Number(e.target.value))}
+                />
+                <span className="text-info me-2">{brightness}</span>
+                <button
+                  className="retro-button btn-sm"
+                  onClick={handleSetBrightness}
+                >
+                  SET
+                </button>
+              </div>
             </div>
-          </div>
-          <div className="mb-2">
-            <label className="form-label text-info">DAW BANK:</label>
-            <div className="d-flex align-items-center">
+            <div className="mb-3">
+              <label className="form-check-label text-info me-2">
+                SLEEP MODE:
+              </label>
               <input
-                type="number"
-                className="form-control retro-input me-2"
-                style={{ width: '80px' }}
-                min="0"
-                max="7"
-                value={dawBank}
-                onChange={(e) => setDawBank(Number(e.target.value))}
+                type="checkbox"
+                className="form-check-input me-2"
+                checked={sleepEnabled}
+                onChange={(e) => setSleepEnabled(e.target.checked)}
               />
-              <button className="retro-button btn-sm" onClick={handleSetDAW}>
-                SET
+              <button className="retro-button btn-sm" onClick={handleSetSleep}>
+                APPLY
               </button>
             </div>
-          </div>
-        </div>
-
-        <div className="col-md-4">
-          <h5 className="text-info">LED CONTROL:</h5>
-          <div className="mb-3">
-            <label className="form-label text-info">BRIGHTNESS:</label>
-            <div className="d-flex align-items-center">
-              <input
-                type="range"
-                className="form-range me-2"
-                min="0"
-                max="127"
-                value={brightness}
-                onChange={(e) => setBrightnessValue(Number(e.target.value))}
-              />
-              <span className="text-info me-2">{brightness}</span>
-              <button
-                className="retro-button btn-sm"
-                onClick={handleSetBrightness}
-              >
-                SET
-              </button>
-            </div>
-          </div>
-          <div className="mb-3">
-            <label className="form-check-label text-info me-2">
-              SLEEP MODE:
-            </label>
-            <input
-              type="checkbox"
-              className="form-check-input me-2"
-              checked={sleepEnabled}
-              onChange={(e) => setSleepEnabled(e.target.checked)}
-            />
-            <button className="retro-button btn-sm" onClick={handleSetSleep}>
-              APPLY
+            <button className="retro-button me-2 mb-2" onClick={handleClearAll}>
+              CLEAR ALL
+            </button>
+            <button
+              className="retro-button me-2 mb-2"
+              onClick={handleClearConfig}
+            >
+              CLEAR CONFIG
+            </button>
+            <button
+              className="retro-button mb-2"
+              onClick={handleLoadToLaunchpad}
+            >
+              LOAD INTO LAUNCHPAD
             </button>
           </div>
-          <button className="retro-button me-2 mb-2" onClick={handleClearAll}>
-            CLEAR ALL
-          </button>
-          <button
-            className="retro-button me-2 mb-2"
-            onClick={handleClearConfig}
-          >
-            CLEAR CONFIG
-          </button>
-          <button className="retro-button mb-2" onClick={handleLoadToLaunchpad}>
-            LOAD INTO LAUNCHPAD
-          </button>
-        </div>
 
-        <div className="col-md-4">
-          <h5 className="text-info">TEXT DISPLAY:</h5>
-          <div className="mb-3">
-            <label className="form-label text-info">MESSAGE:</label>
-            <div className="d-flex">
-              <input
-                type="text"
-                className="form-control retro-input me-2"
-                value={scrollTextValue}
-                onChange={(e) => setScrollTextValue(e.target.value)}
-                maxLength={32}
-              />
-              <button
-                className="retro-button btn-sm"
-                onClick={handleScrollText}
-              >
-                SCROLL
-              </button>
+          <div className="col-md-4">
+            <h5 className="text-info">TEXT DISPLAY:</h5>
+            <div className="mb-3">
+              <label className="form-label text-info">MESSAGE:</label>
+              <div className="d-flex">
+                <input
+                  type="text"
+                  className="form-control retro-input me-2"
+                  value={scrollTextValue}
+                  onChange={(e) => setScrollTextValue(e.target.value)}
+                  maxLength={32}
+                />
+                <button
+                  className="retro-button btn-sm"
+                  onClick={handleScrollText}
+                >
+                  SCROLL
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div className="row">
         <div className="col-12">

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -61,110 +61,122 @@ export default function MacroList() {
         <div>
           {macros.map((m) => (
             <div key={m.id} className="macro-list-item">
-              {editingId === m.id ? (
-                <div className="w-100">
-                  <div className="d-flex flex-wrap mb-1">
-                    <input
-                      className="form-control retro-input me-2 mb-1"
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                    />
-                    <select
-                      className="form-control retro-input me-2 mb-1"
-                      value={type}
-                      onChange={(e) =>
-                        setType(e.target.value as 'keys' | 'app' | 'shell')
-                      }
-                    >
-                      <option value="keys">Keys</option>
-                      <option value="app">Application</option>
-                      <option value="shell">Shell</option>
-                    </select>
-                    {type === 'keys' ? (
-                      <>
-                        <input
-                          className="form-control retro-input me-2 mb-1"
-                          value={sequence}
-                          onChange={(e) => setSequence(e.target.value)}
-                        />
-                        <input
-                          type="number"
-                          className="form-control retro-input me-2 mb-1"
-                          style={{ width: '80px' }}
-                          value={interval}
-                          onChange={(e) => setInterval(Number(e.target.value))}
-                        />
-                      </>
-                    ) : (
-                      <input
-                        className="form-control retro-input me-2 mb-1"
-                        value={command}
-                        onChange={(e) => setCommand(e.target.value)}
-                      />
-                    )}
-                    <select
-                      className="form-control retro-input me-2 mb-1"
-                      value={nextId}
-                      onChange={(e) => setNextId(e.target.value)}
-                    >
-                      <option value="">-- next macro --</option>
-                      {macros.map((o) => (
-                        <option key={o.id} value={o.id}>
-                          {o.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <button
-                      className="retro-button btn-sm me-1"
-                      onClick={saveEdit}
-                    >
-                      SAVE
-                    </button>
-                    <button
-                      className="retro-button btn-sm"
-                      onClick={cancelEdit}
-                    >
-                      CANCEL
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <span className="macro-name">{m.name}</span>
-                  <div>
-                    <button
-                      className="retro-button btn-sm me-1"
-                      onClick={() => playMacro(m.id)}
-                    >
-                      PLAY
-                    </button>
-                    <span className="ms-2 text-info">
-                      {m.type === 'keys'
-                        ? `${m.sequence?.join(' ')} (${m.interval}ms)`
-                        : m.command}
-                    </span>
-                    <button
-                      className="retro-button btn-sm ms-1"
-                      onClick={() => startEdit(m.id)}
-                    >
-                      EDIT
-                    </button>
-                    <button
-                      className="retro-button btn-sm ms-1"
-                      onClick={() => {
-                        removeMacro(m.id);
-                        addToast('Macro deleted', 'success');
-                      }}
-                    >
-                      DEL
-                    </button>
-                  </div>
-                </>
-              )}
+              <span className="macro-name">
+                {m.name}
+                <small className="ms-1 text-info">
+                  (
+                  {(() => {
+                    const txt =
+                      m.type === 'keys'
+                        ? `${(m.sequence || []).join(' ')} (${m.interval ?? 0}ms)`
+                        : m.command || '';
+                    return txt.length > 20 ? `${txt.slice(0, 20)}…` : txt;
+                  })()}
+                  )
+                </small>
+              </span>
+              <div>
+                <button
+                  className="retro-button btn-sm me-1"
+                  onClick={() => playMacro(m.id)}
+                >
+                  PLAY
+                </button>
+                <button
+                  className="retro-button btn-sm me-1"
+                  onClick={() => startEdit(m.id)}
+                >
+                  PREVIEW
+                </button>
+                <button
+                  className="retro-button btn-sm me-1"
+                  onClick={() => {
+                    removeMacro(m.id);
+                    addToast('Macro deleted', 'success');
+                  }}
+                >
+                  DEL
+                </button>
+              </div>
             </div>
           ))}
+        </div>
+      )}
+      {editingId && (
+        <div
+          className="modal d-block"
+          style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
+          onClick={cancelEdit}
+        >
+          <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-content modal-retro">
+              <div className="modal-header">
+                <h5 className="modal-title">EDIT MACRO</h5>
+              </div>
+              <div className="modal-body">
+                <div className="d-flex flex-wrap mb-2">
+                  <input
+                    className="form-control retro-input me-2 mb-1"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                  />
+                  <select
+                    className="form-control retro-input me-2 mb-1"
+                    value={type}
+                    onChange={(e) =>
+                      setType(e.target.value as 'keys' | 'app' | 'shell')
+                    }
+                  >
+                    <option value="keys">Keys</option>
+                    <option value="app">Application</option>
+                    <option value="shell">Shell</option>
+                  </select>
+                  {type === 'keys' ? (
+                    <>
+                      <input
+                        className="form-control retro-input me-2 mb-1"
+                        value={sequence}
+                        onChange={(e) => setSequence(e.target.value)}
+                      />
+                      <input
+                        type="number"
+                        className="form-control retro-input me-2 mb-1"
+                        style={{ width: '80px' }}
+                        value={interval}
+                        onChange={(e) => setInterval(Number(e.target.value))}
+                      />
+                    </>
+                  ) : (
+                    <input
+                      className="form-control retro-input me-2 mb-1"
+                      value={command}
+                      onChange={(e) => setCommand(e.target.value)}
+                    />
+                  )}
+                  <select
+                    className="form-control retro-input me-2 mb-1"
+                    value={nextId}
+                    onChange={(e) => setNextId(e.target.value)}
+                  >
+                    <option value="">-- next macro --</option>
+                    {macros.map((o) => (
+                      <option key={o.id} value={o.id}>
+                        {o.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button className="retro-button me-2" onClick={saveEdit}>
+                  SAVE
+                </button>
+                <button className="retro-button" onClick={cancelEdit}>
+                  CANCEL
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/PadOptionsPanel.tsx
+++ b/src/PadOptionsPanel.tsx
@@ -104,6 +104,15 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
     <div className="pad-options-panel" onClick={(e) => e.stopPropagation()}>
       <h4>PAD {pad.id}</h4>
       <div className="mb-3">
+        <label className="form-label text-info">LABEL:</label>
+        <input
+          className="form-control retro-input"
+          value={label}
+          onChange={handleLabelChange}
+          placeholder="Label"
+        />
+      </div>
+      <div className="mb-3">
         <label className="form-label text-info">STATIC COLOR:</label>
         <select
           className="form-select retro-select"
@@ -193,15 +202,6 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
         </div>
       </div>
       <div className="mb-3">
-        <label className="form-label text-info">LABEL:</label>
-        <input
-          className="form-control retro-input"
-          value={label}
-          onChange={handleLabelChange}
-          placeholder="Label"
-        />
-      </div>
-      <div className="mb-3">
         <label className="form-label text-info">ON NOTE ON:</label>
         <select
           className="form-select retro-select"
@@ -246,6 +246,26 @@ export default function PadOptionsPanel({ pad, onClose }: Props) {
           htmlFor={`confirm-${pad.id}`}
         >
           CONFIRM BEFORE PLAY
+        </label>
+      </div>
+      <div className="form-check mb-3">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          id={`toast-${pad.id}`}
+          checked={action.confirmToast || false}
+          onChange={(e) =>
+            setPadAction(pad.id, {
+              ...action,
+              confirmToast: e.target.checked,
+            })
+          }
+        />
+        <label
+          className="form-check-label text-info"
+          htmlFor={`toast-${pad.id}`}
+        >
+          TOAST CONFIRMATION
         </label>
       </div>
       <button className="retro-button me-2" onClick={clearPad}>

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -21,6 +21,8 @@ export default function SettingsModal({ onClose }: Props) {
   const pingEnabled = useStore((s) => s.settings.pingEnabled);
   const clearBeforeLoad = useStore((s) => s.settings.clearBeforeLoad);
   const sysexColorMode = useStore((s) => s.settings.sysexColorMode);
+  const autoSleep = useStore((s) => s.settings.autoSleep);
+  const theme = useStore((s) => s.settings.theme);
   const clock = useStore((s) => s.settings.clock ?? [0xf8]);
   const setHost = useStore((s) => s.setHost);
   const setPort = useStore((s) => s.setPort);
@@ -35,6 +37,8 @@ export default function SettingsModal({ onClose }: Props) {
   const setPingEnabled = useStore((s) => s.setPingEnabled);
   const setClearBeforeLoad = useStore((s) => s.setClearBeforeLoad);
   const setSysexColorMode = useStore((s) => s.setSysexColorMode);
+  const setAutoSleep = useStore((s) => s.setAutoSleep);
+  const setTheme = useStore((s) => s.setTheme);
   const setClock = useStore((s) => s.setClock);
   const addToast = useToastStore((s) => s.addToast);
 
@@ -51,6 +55,8 @@ export default function SettingsModal({ onClose }: Props) {
   const [pe, setPe] = useState(pingEnabled);
   const [cbl, setCbl] = useState(clearBeforeLoad);
   const [scm, setScm] = useState(sysexColorMode);
+  const [asleep, setAsleep] = useState(autoSleep);
+  const [thm, setThm] = useState(theme);
   const [clk, setClk] = useState(clock.join(' '));
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -68,6 +74,8 @@ export default function SettingsModal({ onClose }: Props) {
     setPingOrange(po);
     setClearBeforeLoad(cbl);
     setSysexColorMode(scm);
+    setAutoSleep(asleep);
+    setTheme(thm);
     setClock(
       clk
         .split(/\s+/)
@@ -111,6 +119,8 @@ export default function SettingsModal({ onClose }: Props) {
         setPingOrange(cfg.pingOrange ?? po);
         setClearBeforeLoad(cfg.clearBeforeLoad ?? cbl);
         setSysexColorMode(cfg.sysexColorMode ?? scm);
+        setAutoSleep(cfg.autoSleep ?? asleep);
+        setTheme(cfg.theme ?? thm);
         setClock(Array.isArray(cfg.clock) ? cfg.clock : clock);
         setH(cfg.host ?? h);
         setP(cfg.port ?? p);
@@ -125,6 +135,8 @@ export default function SettingsModal({ onClose }: Props) {
         setPe(cfg.pingEnabled ?? pe);
         setCbl(cfg.clearBeforeLoad ?? cbl);
         setScm(cfg.sysexColorMode ?? scm);
+        setAsleep(cfg.autoSleep ?? asleep);
+        setThm(cfg.theme ?? thm);
         setClk(
           (Array.isArray(cfg.clock) ? cfg.clock : clock)
             .map((n: number) => n.toString())
@@ -306,6 +318,31 @@ export default function SettingsModal({ onClose }: Props) {
               >
                 SYSEX COLOR MODE
               </label>
+            </div>
+            <div className="mb-3">
+              <label className="form-label text-info">AUTO SLEEP (SEC):</label>
+              <input
+                type="number"
+                className="form-control retro-input"
+                value={asleep}
+                onChange={(e) => setAsleep(Number(e.target.value))}
+                min="0"
+              />
+              <small className="text-warning">0 disables auto sleep</small>
+            </div>
+            <div className="mb-3">
+              <label className="form-label text-info">THEME:</label>
+              <select
+                className="form-select retro-select"
+                value={thm}
+                onChange={(e) =>
+                  setThm(e.target.value as 'default' | 'dark' | 'light')
+                }
+              >
+                <option value="default">Default</option>
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+              </select>
             </div>
             <div className="mb-3">
               <label className="form-label text-info">CLOCK MESSAGE:</label>

--- a/src/index.css
+++ b/src/index.css
@@ -4,9 +4,15 @@
   font-weight: 400;
   font-size: 16px;
 
+  --fg: #00ff00;
+  --bg-start: #000080;
+  --bg-end: #000040;
+  --panel-bg: #000080;
+  --panel-border: #00ffff;
+  --highlight: #ffff00;
   color-scheme: dark;
-  color: #00ff00;
-  background-color: #000080;
+  color: var(--fg);
+  background-color: var(--bg-start);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -18,20 +24,20 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background: linear-gradient(45deg, #000080, #000040);
+  background: linear-gradient(45deg, var(--bg-start), var(--bg-end));
   overflow-x: auto;
 }
 
 .retro-container {
-  background: #000080;
-  border: 2px solid #00ffff;
-  box-shadow: 0 0 20px #00ffff;
+  background: var(--panel-bg);
+  border: 2px solid var(--panel-border);
+  box-shadow: 0 0 20px var(--panel-border);
   margin: 10px;
   padding: 15px;
 }
 
 .retro-title {
-  color: #ffff00;
+  color: var(--highlight);
   text-shadow: 2px 2px 0px #ff00ff;
   font-size: 2.5rem;
   text-align: center;
@@ -687,4 +693,27 @@ body {
     opacity: 0;
     transform: translateY(20px);
   }
+}
+
+body.theme-dark {
+  --bg-start: #000000;
+  --bg-end: #000000;
+  --panel-bg: #000000;
+  --panel-border: #00aaaa;
+  --fg: #00ff00;
+  --highlight: #ffff00;
+  color-scheme: dark;
+  color: var(--fg);
+  background-color: var(--bg-start);
+}
+body.theme-light {
+  --bg-start: #ffffff;
+  --bg-end: #e0e0e0;
+  --panel-bg: #ffffff;
+  --panel-border: #000000;
+  --fg: #000000;
+  --highlight: #000080;
+  color-scheme: light;
+  color: var(--fg);
+  background-color: var(--bg-start);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,6 +39,7 @@ export interface PadActions {
   noteOn?: string;
   noteOff?: string;
   confirm?: boolean;
+  confirmToast?: boolean;
 }
 
 interface PadsSlice {
@@ -87,6 +88,8 @@ interface SettingsSlice {
     pingEnabled: boolean;
     clearBeforeLoad: boolean;
     sysexColorMode: boolean;
+    autoSleep: number;
+    theme: 'default' | 'dark' | 'light';
     clock: number[];
   };
   setHost: (h: string) => void;
@@ -102,6 +105,8 @@ interface SettingsSlice {
   setPingEnabled: (enabled: boolean) => void;
   setClearBeforeLoad: (enabled: boolean) => void;
   setSysexColorMode: (enabled: boolean) => void;
+  setAutoSleep: (s: number) => void;
+  setTheme: (t: 'default' | 'dark' | 'light') => void;
   setClock: (data: number[]) => void;
 }
 
@@ -184,6 +189,8 @@ export const useStore = create<StoreState>()(
         pingEnabled: true,
         clearBeforeLoad: false,
         sysexColorMode: false,
+        autoSleep: 0,
+        theme: 'default',
         clock: [0xf8],
       },
       setHost: (h) =>
@@ -258,6 +265,14 @@ export const useStore = create<StoreState>()(
         set((state) => ({
           settings: { ...state.settings, sysexColorMode: enabled },
         })),
+      setAutoSleep: (s) =>
+        set((state) => ({
+          settings: { ...state.settings, autoSleep: Math.max(0, s) },
+        })),
+      setTheme: (t) =>
+        set((state) => ({
+          settings: { ...state.settings, theme: t },
+        })),
       setClock: (data) =>
         set((state) => ({
           settings: { ...state.settings, clock: data },
@@ -289,6 +304,8 @@ export const useStore = create<StoreState>()(
             clock: p.settings?.clock ?? current.settings.clock,
             sysexColorMode:
               p.settings?.sysexColorMode ?? current.settings.sysexColorMode,
+            autoSleep: p.settings?.autoSleep ?? current.settings.autoSleep,
+            theme: p.settings?.theme ?? current.settings.theme,
           },
         };
       },

--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -1,13 +1,17 @@
 import { useCallback } from 'react';
 import { useStore } from './store';
+import { useToastStore } from './toastStore';
 
 export function useKeyMacroPlayer() {
   const macros = useStore((s) => s.macros);
+  const addToast = useToastStore.getState().addToast;
 
   const playMacro = useCallback(
     async (macroId: string) => {
       const macro = macros.find((m) => m.id === macroId);
       if (!macro) return;
+      console.log('Playing macro', macro);
+      addToast(`Playing: ${macro.name}`, 'success');
       try {
         if (macro.type === 'app') {
           await fetch('/run/app', {

--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -3,6 +3,7 @@ import { useMidi, type MidiMessage } from './useMidi';
 import { useStore } from './store';
 import { useKeyMacroPlayer } from './useKeyMacroPlayer';
 import { notify } from './notify';
+import { useToastStore } from './toastStore';
 import LAUNCHPAD_COLORS from './launchpadColors';
 import { noteOn, cc, lightingSysEx } from './midiMessages';
 
@@ -40,7 +41,13 @@ export function usePadActions() {
     }
   };
 
-  const handleMacro = (macroId: string, id: string, confirm?: boolean) => {
+  const handleMacro = (
+    macroId: string,
+    id: string,
+    confirm?: boolean,
+    toastConfirm?: boolean,
+  ) => {
+    console.log('Pad macro trigger', { macroId, id, confirm, toastConfirm });
     if (!confirm) {
       playMacro(macroId);
       return;
@@ -50,7 +57,13 @@ export function usePadActions() {
       const prev = padChannels[id] || 1;
       setPadChannel(id, 3);
       sendPadState(id, 3);
-      notify('Press pad again to confirm');
+      if (toastConfirm) {
+        useToastStore
+          .getState()
+          .addToast('Press pad again to confirm', 'success');
+      } else {
+        notify('Press pad again to confirm');
+      }
       const t = setTimeout(() => {
         setPadChannel(id, prev);
         sendPadState(id, prev);
@@ -90,9 +103,9 @@ export function usePadActions() {
       const action = padActions[padId];
       if (!action) return;
       if (isOn && action.noteOn) {
-        handleMacro(action.noteOn, padId, action.confirm);
+        handleMacro(action.noteOn, padId, action.confirm, action.confirmToast);
       } else if (!isOn && action.noteOff) {
-        handleMacro(action.noteOff, padId, action.confirm);
+        handleMacro(action.noteOff, padId, action.confirm, action.confirmToast);
       }
     };
 


### PR DESCRIPTION
## Summary
- switch to toasted-notifier for system notifications
- add macro preview modal and toast on play
- support per-pad toast confirmation and move label field
- collapse advanced Launchpad toolbox options
- introduce auto sleep and theme settings
- expose themes via CSS variables

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bb1a7cd5c8325a9c580d6c865553a