### PR TITLE
Add macro import/export

### DIFF
--- a/src/MacroImportModal.tsx
+++ b/src/MacroImportModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { useStore, type Macro } from './store';
+import { useToastStore } from './toastStore';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function MacroImportModal({ onClose }: Props) {
+  const addToast = useToastStore((s) => s.addToast);
+  const [data, setData] = useState<Macro[] | null>(null);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const parsed = JSON.parse(ev.target?.result as string);
+        if (!Array.isArray(parsed)) throw new Error('Invalid format');
+        setData(parsed as Macro[]);
+      } catch {
+        setData(null);
+        addToast('Failed to parse file', 'error');
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  const confirmImport = () => {
+    if (!data) return;
+    useStore.setState((s) => ({ ...s, macros: data }));
+    addToast('Macros imported', 'success');
+    onClose();
+  };
+
+  return (
+    <div
+      className="modal d-block"
+      style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
+      onClick={onClose}
+    >
+      <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-content modal-retro">
+          <div className="modal-header">
+            <h5 className="modal-title">IMPORT MACROS</h5>
+          </div>
+          <div className="modal-body">
+            <input
+              type="file"
+              accept="application/json"
+              onChange={handleFile}
+            />
+          </div>
+          <div className="modal-footer">
+            <button
+              className="retro-button me-2"
+              onClick={confirmImport}
+              disabled={!data}
+            >
+              IMPORT
+            </button>
+            <button className="retro-button" onClick={onClose}>
+              CANCEL
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -2,6 +2,7 @@ import { useKeyMacroPlayer } from './useKeyMacroPlayer';
 import { useStore, type Macro } from './store';
 import { useToastStore } from './toastStore';
 import { useState } from 'react';
+import MacroImportModal from './MacroImportModal';
 
 export default function MacroList() {
   const macros = useStore((s) => s.macros);
@@ -16,6 +17,7 @@ export default function MacroList() {
   const [type, setType] = useState<'keys' | 'app' | 'shell'>('keys');
   const [command, setCommand] = useState('');
   const [nextId, setNextId] = useState('');
+  const [showImport, setShowImport] = useState(false);
 
   const startEdit = (id: string) => {
     const m = macros.find((x) => x.id === id);
@@ -52,9 +54,34 @@ export default function MacroList() {
 
   const cancelEdit = () => setEditingId(null);
 
+  const exportMacros = () => {
+    const data = JSON.stringify(macros);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'macros.json';
+    a.click();
+    URL.revokeObjectURL(url);
+    addToast('Macros exported', 'success');
+  };
+
   return (
     <div className="retro-panel">
-      <h3>◄ Macro Sequencer ►</h3>
+      <div className="d-flex justify-content-between align-items-center mb-2">
+        <h3 className="m-0">◄ Macro Sequencer ►</h3>
+        <div>
+          <button className="retro-button btn-sm me-1" onClick={exportMacros}>
+            EXPORT
+          </button>
+          <button
+            className="retro-button btn-sm"
+            onClick={() => setShowImport(true)}
+          >
+            IMPORT
+          </button>
+        </div>
+      </div>
       {macros.length === 0 ? (
         <div className="text-warning text-center p-3">NO MACROS LOADED</div>
       ) : (
@@ -179,6 +206,7 @@ export default function MacroList() {
           </div>
         </div>
       )}
+      {showImport && <MacroImportModal onClose={() => setShowImport(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `MacroImportModal` component for importing macros from file
- extend `MacroList` with export and import controls

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c0dad8e5083259c90fdaeec0d0cbd