### PR TITLE
Implement shell macro variations

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -4,7 +4,7 @@ const { WebMidi } = require('webmidi');
 const keySender = require('node-key-sender');
 const notifier = require('toasted-notifier');
 const cors = require('cors');
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
 
 const app = express();
 app.use(express.json());
@@ -122,6 +122,44 @@ WebMidi.enable({ sysex: true })
       exec(cmd, (err) => {
         if (err) {
           console.error('Shell exec error:', err);
+          res.status(500).json({ error: err.message });
+        } else {
+          res.json({ ok: true });
+        }
+      });
+    });
+
+    app.post('/run/shellWin', (req, res) => {
+      const { cmd } = req.body || {};
+      console.log('Run shellWin request:', cmd);
+      if (!cmd) {
+        res.status(400).json({ error: 'cmd required' });
+        return;
+      }
+      try {
+        const child = spawn(cmd, {
+          shell: true,
+          detached: true,
+          windowsHide: false,
+        });
+        child.unref();
+        res.json({ ok: true });
+      } catch (err) {
+        console.error('ShellWin spawn error:', err);
+        res.status(500).json({ error: err.message });
+      }
+    });
+
+    app.post('/run/shellBg', (req, res) => {
+      const { cmd } = req.body || {};
+      console.log('Run shellBg request:', cmd);
+      if (!cmd) {
+        res.status(400).json({ error: 'cmd required' });
+        return;
+      }
+      exec(cmd, { windowsHide: true }, (err) => {
+        if (err) {
+          console.error('ShellBg exec error:', err);
           res.status(500).json({ error: err.message });
         } else {
           res.json({ ok: true });

--- a/src/MacroBuilder.tsx
+++ b/src/MacroBuilder.tsx
@@ -9,7 +9,9 @@ export default function MacroBuilder() {
   const [name, setName] = useState('');
   const [sequence, setSequence] = useState('');
   const [interval, setInterval] = useState(50);
-  const [type, setType] = useState<'keys' | 'app' | 'shell'>('keys');
+  const [type, setType] = useState<
+    'keys' | 'app' | 'shell' | 'shell_win' | 'shell_bg'
+  >('keys');
   const [command, setCommand] = useState('');
   const [nextId, setNextId] = useState('');
 
@@ -61,12 +63,21 @@ export default function MacroBuilder() {
           className="form-control retro-input me-2 mb-1"
           value={type}
           onChange={(e) =>
-            setType(e.target.value as 'keys' | 'app' | 'shell')
+            setType(
+              e.target.value as
+                | 'keys'
+                | 'app'
+                | 'shell'
+                | 'shell_win'
+                | 'shell_bg',
+            )
           }
         >
           <option value="keys">Keys</option>
           <option value="app">Application</option>
           <option value="shell">Shell</option>
+          <option value="shell_win">Shell (Window)</option>
+          <option value="shell_bg">Shell (Hidden)</option>
         </select>
         {type === 'keys' ? (
           <>

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -14,7 +14,9 @@ export default function MacroList() {
   const [name, setName] = useState('');
   const [sequence, setSequence] = useState('');
   const [interval, setInterval] = useState(50);
-  const [type, setType] = useState<'keys' | 'app' | 'shell'>('keys');
+  const [type, setType] = useState<
+    'keys' | 'app' | 'shell' | 'shell_win' | 'shell_bg'
+  >('keys');
   const [command, setCommand] = useState('');
   const [nextId, setNextId] = useState('');
   const [showImport, setShowImport] = useState(false);
@@ -151,12 +153,21 @@ export default function MacroList() {
                     className="form-control retro-input me-2 mb-1"
                     value={type}
                     onChange={(e) =>
-                      setType(e.target.value as 'keys' | 'app' | 'shell')
+                      setType(
+                        e.target.value as
+                          | 'keys'
+                          | 'app'
+                          | 'shell'
+                          | 'shell_win'
+                          | 'shell_bg',
+                      )
                     }
                   >
                     <option value="keys">Keys</option>
                     <option value="app">Application</option>
                     <option value="shell">Shell</option>
+                    <option value="shell_win">Shell (Window)</option>
+                    <option value="shell_bg">Shell (Hidden)</option>
                   </select>
                   {type === 'keys' ? (
                     <>

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,7 +12,7 @@ export interface Macro {
   name: string;
   sequence?: string[];
   interval?: number;
-  type?: 'keys' | 'app' | 'shell';
+  type?: 'keys' | 'app' | 'shell' | 'shell_win' | 'shell_bg';
   command?: string;
   nextId?: string;
 }

--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -25,6 +25,18 @@ export function useKeyMacroPlayer() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ cmd: macro.command }),
           });
+        } else if (macro.type === 'shell_win') {
+          await fetch('/run/shellWin', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cmd: macro.command }),
+          });
+        } else if (macro.type === 'shell_bg') {
+          await fetch('/run/shellBg', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cmd: macro.command }),
+          });
         } else {
           await fetch('/keys/type', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- extend `Macro['type']` to include `shell_win` and `shell_bg`
- add shell options to macro forms
- create `/run/shellWin` and `/run/shellBg` endpoints
- trigger new endpoints from macro player

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c614d70d883258632b38d4285f3c3