### PR TITLE
Add auto load first config setting

### DIFF
--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useStore, type PadConfig } from './store';
 import { useToastStore } from './toastStore';
 import { useMidi } from './useMidi';
@@ -25,6 +25,7 @@ export default function ConfigManager() {
   const setPadActions = useStore((s) => s.setPadActions);
   const clearBeforeLoad = useStore((s) => s.settings.clearBeforeLoad);
   const sysexColorMode = useStore((s) => s.settings.sysexColorMode);
+  const autoLoadFirstConfig = useStore((s) => s.settings.autoLoadFirstConfig);
   const updateConfig = useStore((s) => s.updateConfig);
   const addToast = useToastStore((s) => s.addToast);
   const { send } = useMidi();
@@ -32,6 +33,13 @@ export default function ConfigManager() {
   const [editName, setEditName] = useState('');
   const [name, setName] = useState('');
   const [confirmDelete, setConfirmDelete] = useState<PadConfig | null>(null);
+
+  useEffect(() => {
+    if (autoLoadFirstConfig && configs.length > 0) {
+      loadConfig(configs[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const saveCurrent = () => {
     if (!name.trim()) return;

--- a/src/MacroInstructions.tsx
+++ b/src/MacroInstructions.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface Props {
   onClose: () => void;
 }

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -22,6 +22,7 @@ export default function SettingsModal({ onClose }: Props) {
   const clearBeforeLoad = useStore((s) => s.settings.clearBeforeLoad);
   const sysexColorMode = useStore((s) => s.settings.sysexColorMode);
   const autoSleep = useStore((s) => s.settings.autoSleep);
+  const autoLoadFirstConfig = useStore((s) => s.settings.autoLoadFirstConfig);
   const theme = useStore((s) => s.settings.theme);
   const clock = useStore((s) => s.settings.clock ?? [0xf8]);
   const setHost = useStore((s) => s.setHost);
@@ -38,6 +39,7 @@ export default function SettingsModal({ onClose }: Props) {
   const setClearBeforeLoad = useStore((s) => s.setClearBeforeLoad);
   const setSysexColorMode = useStore((s) => s.setSysexColorMode);
   const setAutoSleep = useStore((s) => s.setAutoSleep);
+  const setAutoLoadFirstConfig = useStore((s) => s.setAutoLoadFirstConfig);
   const setTheme = useStore((s) => s.setTheme);
   const setClock = useStore((s) => s.setClock);
   const addToast = useToastStore((s) => s.addToast);
@@ -56,6 +58,7 @@ export default function SettingsModal({ onClose }: Props) {
   const [cbl, setCbl] = useState(clearBeforeLoad);
   const [scm, setScm] = useState(sysexColorMode);
   const [asleep, setAsleep] = useState(autoSleep);
+  const [alfc, setAlfc] = useState(autoLoadFirstConfig);
   const [thm, setThm] = useState(theme);
   const [clk, setClk] = useState(clock.join(' '));
   const fileRef = useRef<HTMLInputElement>(null);
@@ -75,6 +78,7 @@ export default function SettingsModal({ onClose }: Props) {
     setClearBeforeLoad(cbl);
     setSysexColorMode(scm);
     setAutoSleep(asleep);
+    setAutoLoadFirstConfig(alfc);
     setTheme(thm);
     setClock(
       clk
@@ -120,6 +124,7 @@ export default function SettingsModal({ onClose }: Props) {
         setClearBeforeLoad(cfg.clearBeforeLoad ?? cbl);
         setSysexColorMode(cfg.sysexColorMode ?? scm);
         setAutoSleep(cfg.autoSleep ?? asleep);
+        setAutoLoadFirstConfig(cfg.autoLoadFirstConfig ?? alfc);
         setTheme(cfg.theme ?? thm);
         setClock(Array.isArray(cfg.clock) ? cfg.clock : clock);
         setH(cfg.host ?? h);
@@ -136,6 +141,7 @@ export default function SettingsModal({ onClose }: Props) {
         setCbl(cfg.clearBeforeLoad ?? cbl);
         setScm(cfg.sysexColorMode ?? scm);
         setAsleep(cfg.autoSleep ?? asleep);
+        setAlfc(cfg.autoLoadFirstConfig ?? alfc);
         setThm(cfg.theme ?? thm);
         setClk(
           (Array.isArray(cfg.clock) ? cfg.clock : clock)
@@ -317,6 +323,21 @@ export default function SettingsModal({ onClose }: Props) {
                 htmlFor="sysexColorMode"
               >
                 SYSEX COLOR MODE
+              </label>
+            </div>
+            <div className="mb-3 form-check">
+              <input
+                type="checkbox"
+                className="form-check-input"
+                id="autoLoadFirstConfig"
+                checked={alfc}
+                onChange={(e) => setAlfc(e.target.checked)}
+              />
+              <label
+                className="form-check-label text-info"
+                htmlFor="autoLoadFirstConfig"
+              >
+                AUTO-LOAD FIRST CONFIG
               </label>
             </div>
             <div className="mb-3">

--- a/src/store.ts
+++ b/src/store.ts
@@ -90,6 +90,7 @@ interface SettingsSlice {
     sysexColorMode: boolean;
     autoSleep: number;
     theme: 'default' | 'dark' | 'light';
+    autoLoadFirstConfig: boolean;
     clock: number[];
   };
   setHost: (h: string) => void;
@@ -107,6 +108,7 @@ interface SettingsSlice {
   setSysexColorMode: (enabled: boolean) => void;
   setAutoSleep: (s: number) => void;
   setTheme: (t: 'default' | 'dark' | 'light') => void;
+  setAutoLoadFirstConfig: (b: boolean) => void;
   setClock: (data: number[]) => void;
 }
 
@@ -191,6 +193,7 @@ export const useStore = create<StoreState>()(
         sysexColorMode: false,
         autoSleep: 0,
         theme: 'default',
+        autoLoadFirstConfig: false,
         clock: [0xf8],
       },
       setHost: (h) =>
@@ -273,6 +276,10 @@ export const useStore = create<StoreState>()(
         set((state) => ({
           settings: { ...state.settings, theme: t },
         })),
+      setAutoLoadFirstConfig: (b) =>
+        set((state) => ({
+          settings: { ...state.settings, autoLoadFirstConfig: b },
+        })),
       setClock: (data) =>
         set((state) => ({
           settings: { ...state.settings, clock: data },
@@ -306,6 +313,9 @@ export const useStore = create<StoreState>()(
               p.settings?.sysexColorMode ?? current.settings.sysexColorMode,
             autoSleep: p.settings?.autoSleep ?? current.settings.autoSleep,
             theme: p.settings?.theme ?? current.settings.theme,
+            autoLoadFirstConfig:
+              p.settings?.autoLoadFirstConfig ??
+              current.settings.autoLoadFirstConfig,
           },
         };
       },


### PR DESCRIPTION
## Summary
- extend store settings with `autoLoadFirstConfig`
- expose control in Settings modal
- auto-load the first config on mount
- fix unused import preventing `npm run build`

## Testing
- `npm run format`
- `npm run lint` *(warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c6bcb56cc832586ab7fe0814bbc5a