### PR TITLE
Add macro order controls

### DIFF
--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -9,6 +9,7 @@ export default function MacroList() {
   const macros = useStore((s) => s.macros);
   const removeMacro = useStore((s) => s.removeMacro);
   const updateMacro = useStore((s) => s.updateMacro);
+  const reorderMacro = useStore((s) => s.reorderMacro);
   const addToast = useToastStore((s) => s.addToast);
   const { playMacro } = useKeyMacroPlayer();
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -104,7 +105,7 @@ export default function MacroList() {
         <div className="text-warning text-center p-3">NO MACROS LOADED</div>
       ) : (
         <div>
-          {macros.map((m) => (
+          {macros.map((m, idx) => (
             <div key={m.id} className="macro-list-item">
               <span className="macro-name">
                 {m.name}
@@ -121,6 +122,20 @@ export default function MacroList() {
                 </small>
               </span>
               <div>
+                <button
+                  className="retro-button btn-sm me-1"
+                  disabled={idx === 0}
+                  onClick={() => reorderMacro(idx, idx - 1)}
+                >
+                  ↑
+                </button>
+                <button
+                  className="retro-button btn-sm me-1"
+                  disabled={idx === macros.length - 1}
+                  onClick={() => reorderMacro(idx, idx + 1)}
+                >
+                  ↓
+                </button>
                 <button
                   className="retro-button btn-sm me-1"
                   onClick={() => playMacro(m.id)}

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,7 @@ interface MacrosSlice {
   addMacro: (macro: Macro) => void;
   updateMacro: (macro: Macro) => void;
   removeMacro: (id: string) => void;
+  reorderMacro: (from: number, to: number) => void;
 }
 
 export type PadColourMap = Record<number, string>;
@@ -143,6 +144,20 @@ export const useStore = create<StoreState>()(
         })),
       removeMacro: (id) =>
         set((state) => ({ macros: state.macros.filter((m) => m.id !== id) })),
+      reorderMacro: (from, to) =>
+        set((state) => {
+          const macros = [...state.macros];
+          if (
+            from < 0 ||
+            from >= macros.length ||
+            to < 0 ||
+            to >= macros.length
+          )
+            return { macros };
+          const [m] = macros.splice(from, 1);
+          macros.splice(to, 0, m);
+          return { macros };
+        }),
       padColours: {},
       padLabels: {},
       padChannels: {},


### PR DESCRIPTION
## Summary
- add `reorderMacro` action in the store
- provide UI buttons to move macros up or down

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686cfa6b6110832598aa175611f38e3e