### PR TITLE
Add configuration reordering

### DIFF
--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -15,6 +15,7 @@ export default function ConfigManager() {
   const configs = useStore((s) => s.configs);
   const addConfig = useStore((s) => s.addConfig);
   const removeConfig = useStore((s) => s.removeConfig);
+  const reorderConfig = useStore((s) => s.reorderConfig);
   const setPadColours = useStore((s) => s.setPadColours);
   const setPadLabels = useStore((s) => s.setPadLabels);
   const padColours = useStore((s) => s.padColours);
@@ -174,10 +175,24 @@ export default function ConfigManager() {
       <div className="mb-3">
         <input type="file" accept="application/json" onChange={importConfig} />
       </div>
-      {configs.map((cfg) => (
+      {configs.map((cfg, idx) => (
         <div key={cfg.id} className="macro-list-item">
           <span className="macro-name">{cfg.name}</span>
           <div>
+            <button
+              className="retro-button btn-sm me-1"
+              disabled={idx === 0}
+              onClick={() => reorderConfig(idx, idx - 1)}
+            >
+              ↑
+            </button>
+            <button
+              className="retro-button btn-sm me-1"
+              disabled={idx === configs.length - 1}
+              onClick={() => reorderConfig(idx, idx + 1)}
+            >
+              ↓
+            </button>
             <button
               className="retro-button btn-sm me-1"
               onClick={() => loadConfig(cfg)}

--- a/src/store.ts
+++ b/src/store.ts
@@ -72,6 +72,7 @@ interface ConfigsSlice {
   addConfig: (c: PadConfig) => void;
   updateConfig: (c: PadConfig) => void;
   removeConfig: (id: string) => void;
+  reorderConfig: (from: number, to: number) => void;
 }
 
 interface SettingsSlice {
@@ -192,6 +193,20 @@ export const useStore = create<StoreState>()(
         })),
       removeConfig: (id) =>
         set((s) => ({ configs: s.configs.filter((p) => p.id !== id) })),
+      reorderConfig: (from, to) =>
+        set((s) => {
+          const configs = [...s.configs];
+          if (
+            from < 0 ||
+            from >= configs.length ||
+            to < 0 ||
+            to >= configs.length
+          )
+            return { configs };
+          const [c] = configs.splice(from, 1);
+          configs.splice(to, 0, c);
+          return { configs };
+        }),
       settings: {
         host: location.hostname || 'localhost',
         port: 3000,


### PR DESCRIPTION
## Summary
- enable reordering of configs via store
- add move buttons in ConfigManager

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d05eb31548325a5f13a478ec1cc4d