### PR TITLE
Handle outside clicks on Launchpad canvas

### DIFF
--- a/src/LaunchpadCanvas.tsx
+++ b/src/LaunchpadCanvas.tsx
@@ -125,13 +125,21 @@ export function LaunchpadCanvas() {
       />,
     );
   }
+  const handleWrapperClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!selected) return;
+    const target = e.target as HTMLElement;
+    if (target.closest('.pad-options-panel')) return;
+    if (target.closest('.midi-pad-container')) return;
+    setSelected(null);
+  };
+
   return (
-    <>
+    <div className="launchpad-canvas-wrapper" onClick={handleWrapperClick}>
       <div className="midi-grid-fixed">{grid}</div>
       {selected && (
         <PadOptionsPanel pad={selected} onClose={() => setSelected(null)} />
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,10 @@ body {
   color: #00ff00;
 }
 
+.launchpad-canvas-wrapper {
+  position: relative;
+}
+
 .midi-grid-fixed {
   display: grid;
   grid-template-columns: repeat(9, 40px);


### PR DESCRIPTION
## Summary
- wrap Launchpad grid/panel with `launchpad-canvas-wrapper`
- add click handler to close the options panel when clicking outside it
- add style for the new wrapper

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d4514535083259265afd71d88856a