### PR TITLE
Improve shell command security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,24 @@ MIDI messages are forwarded as `midi` events so the UI can react in real time.
 The React code uses `fetch` for the REST calls and opens a WebSocket connection
 to receive device updates and MIDI messages.
 
+### Shell command security
+
+The server exposes endpoints that can execute local shell commands. To avoid
+accidental or malicious use these routes now validate commands against a
+whitelist defined in the `ALLOWED_CMDS` environment variable. Commands that do
+not match the whitelist or contain characters commonly used for injection are
+rejected with a `403` response.
+
+Example:
+
+```bash
+ALLOWED_CMDS="ffmpeg,ls" npm run server
+```
+
+Only `ffmpeg` and `ls` will be accepted by `/run/shell*` routes. Review your
+allowed commands carefully as running arbitrary processes can compromise your
+system.
+
 ---
 
 ## Development workflow


### PR DESCRIPTION
## Summary
- validate commands with a small allowlist before executing
- reject unapproved commands in run routes
- document command restrictions in the Node server section of the README

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d5b488440832593ade2ed4b28c3c5