### PR TITLE
Add setup helper and CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "preview": "vite preview",
-    "server": "node server/index.cjs"
+    "server": "node server/index.cjs",
+    "setup": "npm install"
   },
   "dependencies": {
     "@tonejs/midi": "^2.0.28",

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,16 @@ controlling MIDI devices. When a Launchpad X is detected the app automatically
 switches the controller into _Programmer_ mode so that every pad can be
 addressed individually.
 
+## Setup
+
+Install dependencies before running any lint or build steps:
+
+```bash
+npm run setup
+```
+
+This script simply runs `npm install` to fetch all project packages.
+
 ---
 
 ## Node server
@@ -80,6 +90,7 @@ testing device specific commands.
 ## Useful scripts
 
 - `npm run dev` – start both the backend and Vite dev server
+- `npm run setup` – install all dependencies
 - `npm run build` – build the React application for production
 - `npm run preview` – preview the production build locally
 - `npm run lint` – run ESLint

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Install project dependencies
+npm install


### PR DESCRIPTION
## Summary
- add `npm run setup` script and helper `setup.sh`
- document setup steps and useful script
- add GitHub Actions workflow to run lint and build

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d5b4cbea483258368a842d3f70548