### PR TITLE
Add API key authentication for server and client

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -5,10 +5,25 @@ const keySender = require('node-key-sender');
 const notifier = require('toasted-notifier');
 const cors = require('cors');
 const { exec, spawn } = require('child_process');
+const crypto = require('crypto');
+
+const API_KEY = process.env.API_KEY || crypto.randomBytes(16).toString('hex');
+console.log('API key:', API_KEY);
 
 const app = express();
 app.use(express.json());
 app.use(cors());
+
+function checkKey(req, res, next) {
+  const key = req.headers['x-api-key'];
+  if (key !== API_KEY) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+  next();
+}
+
+app.use(checkKey);
 
 let currentDevices = { inputs: [], outputs: [] };
 
@@ -243,7 +258,12 @@ WebMidi.enable({ sysex: true })
     // Initial setup
     setupMidiListeners();
 
-    wss.on('connection', (ws) => {
+    wss.on('connection', (ws, req) => {
+      const url = new URL(req.url, 'http://localhost');
+      if (url.searchParams.get('key') !== API_KEY) {
+        ws.close();
+        return;
+      }
       console.log('WebSocket client connected');
       sendDevices(ws);
 

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -25,6 +25,7 @@ export default function SettingsModal({ onClose }: Props) {
   const autoLoadFirstConfig = useStore((s) => s.settings.autoLoadFirstConfig);
   const theme = useStore((s) => s.settings.theme);
   const clock = useStore((s) => s.settings.clock ?? [0xf8]);
+  const apiKey = useStore((s) => s.settings.apiKey);
   const setHost = useStore((s) => s.setHost);
   const setPort = useStore((s) => s.setPort);
   const setAutoReconnect = useStore((s) => s.setAutoReconnect);
@@ -42,6 +43,7 @@ export default function SettingsModal({ onClose }: Props) {
   const setAutoLoadFirstConfig = useStore((s) => s.setAutoLoadFirstConfig);
   const setTheme = useStore((s) => s.setTheme);
   const setClock = useStore((s) => s.setClock);
+  const setApiKey = useStore((s) => s.setApiKey);
   const addToast = useToastStore((s) => s.addToast);
 
   const [h, setH] = useState(host);
@@ -60,6 +62,7 @@ export default function SettingsModal({ onClose }: Props) {
   const [asleep, setAsleep] = useState(autoSleep);
   const [alfc, setAlfc] = useState(autoLoadFirstConfig);
   const [thm, setThm] = useState(theme);
+  const [ak, setAk] = useState(apiKey);
   const [clk, setClk] = useState(clock.join(' '));
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -80,6 +83,7 @@ export default function SettingsModal({ onClose }: Props) {
     setAutoSleep(asleep);
     setAutoLoadFirstConfig(alfc);
     setTheme(thm);
+    setApiKey(ak);
     setClock(
       clk
         .split(/\s+/)
@@ -126,6 +130,7 @@ export default function SettingsModal({ onClose }: Props) {
         setAutoSleep(cfg.autoSleep ?? asleep);
         setAutoLoadFirstConfig(cfg.autoLoadFirstConfig ?? alfc);
         setTheme(cfg.theme ?? thm);
+        setApiKey(cfg.apiKey ?? ak);
         setClock(Array.isArray(cfg.clock) ? cfg.clock : clock);
         setH(cfg.host ?? h);
         setP(cfg.port ?? p);
@@ -143,6 +148,7 @@ export default function SettingsModal({ onClose }: Props) {
         setAsleep(cfg.autoSleep ?? asleep);
         setAlfc(cfg.autoLoadFirstConfig ?? alfc);
         setThm(cfg.theme ?? thm);
+        setAk(cfg.apiKey ?? ak);
         setClk(
           (Array.isArray(cfg.clock) ? cfg.clock : clock)
             .map((n: number) => n.toString())
@@ -198,6 +204,15 @@ export default function SettingsModal({ onClose }: Props) {
                 max="65535"
               />
               <small className="text-warning">Default: 3000</small>
+            </div>
+            <div className="mb-3">
+              <label className="form-label text-info">API KEY:</label>
+              <input
+                className="form-control retro-input"
+                value={ak}
+                onChange={(e) => setAk(e.target.value)}
+              />
+              <small className="text-warning">Must match server API key</small>
             </div>
             <div className="mb-3">
               <label className="form-label text-info">MAX LOG ENTRIES:</label>

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,11 +3,14 @@ import { useStore } from './store';
 
 export async function notify(message: string) {
   const addToast = useToastStore.getState().addToast;
-  const { host, port } = useStore.getState().settings;
+  const { host, port, apiKey } = useStore.getState().settings;
   try {
     const res = await fetch(`http://${host}:${port}/notify`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
       body: JSON.stringify({ message }),
     });
     if (!res.ok) throw new Error('Request failed');

--- a/src/store.ts
+++ b/src/store.ts
@@ -95,6 +95,7 @@ interface SettingsSlice {
     autoSleep: number;
     theme: 'default' | 'dark' | 'light';
     autoLoadFirstConfig: boolean;
+    apiKey: string;
     clock: number[];
   };
   setHost: (h: string) => void;
@@ -113,6 +114,7 @@ interface SettingsSlice {
   setAutoSleep: (s: number) => void;
   setTheme: (t: 'default' | 'dark' | 'light') => void;
   setAutoLoadFirstConfig: (b: boolean) => void;
+  setApiKey: (k: string) => void;
   setClock: (data: number[]) => void;
 }
 
@@ -226,6 +228,7 @@ export const useStore = create<StoreState>()(
         autoSleep: 0,
         theme: 'default',
         autoLoadFirstConfig: false,
+        apiKey: '',
         clock: [0xf8],
       },
       setHost: (h) =>
@@ -312,6 +315,8 @@ export const useStore = create<StoreState>()(
         set((state) => ({
           settings: { ...state.settings, autoLoadFirstConfig: b },
         })),
+      setApiKey: (k) =>
+        set((state) => ({ settings: { ...state.settings, apiKey: k } })),
       setClock: (data) =>
         set((state) => ({
           settings: { ...state.settings, clock: data },
@@ -358,6 +363,7 @@ export const useStore = create<StoreState>()(
             autoLoadFirstConfig:
               p.settings?.autoLoadFirstConfig ??
               current.settings.autoLoadFirstConfig,
+            apiKey: p.settings?.apiKey ?? current.settings.apiKey,
           },
         };
       },

--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -5,6 +5,7 @@ import { useToastStore } from './toastStore';
 export function useKeyMacroPlayer() {
   const macros = useStore((s) => s.macros);
   const addToast = useToastStore.getState().addToast;
+  const apiKey = useStore.getState().settings.apiKey;
 
   const playMacro = useCallback(
     async (macroId: string) => {
@@ -16,31 +17,46 @@ export function useKeyMacroPlayer() {
         if (macro.type === 'app') {
           await fetch('/run/app', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+            },
             body: JSON.stringify({ app: macro.command }),
           });
         } else if (macro.type === 'shell') {
           await fetch('/run/shell', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+            },
             body: JSON.stringify({ cmd: macro.command }),
           });
         } else if (macro.type === 'shell_win') {
           await fetch('/run/shellWin', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+            },
             body: JSON.stringify({ cmd: macro.command }),
           });
         } else if (macro.type === 'shell_bg') {
           await fetch('/run/shellBg', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+            },
             body: JSON.stringify({ cmd: macro.command }),
           });
         } else {
           await fetch('/keys/type', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+            },
             body: JSON.stringify({
               sequence: macro.sequence,
               interval: macro.interval,

--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -21,6 +21,7 @@ export interface MidiMessage {
 export function useMidi() {
   const host = useStore((s) => s.settings.host);
   const port = useStore((s) => s.settings.port);
+  const apiKey = useStore((s) => s.settings.apiKey);
   const autoReconnect = useStore((s) => s.settings.autoReconnect);
   const reconnectInterval = useStore((s) => s.settings.reconnectInterval);
   const maxReconnectAttempts = useStore((s) => s.settings.maxReconnectAttempts);
@@ -94,12 +95,12 @@ export function useMidi() {
     }
 
     console.log(
-      `Attempting WebSocket connection to ws://${host}:${port} (attempt ${connectionAttemptsRef.current + 1})`,
+      `Attempting WebSocket connection to ws://${host}:${port}?key=${apiKey} (attempt ${connectionAttemptsRef.current + 1})`,
     );
     setStatus('connecting');
 
     try {
-      const ws = new WebSocket(`ws://${host}:${port}`);
+      const ws = new WebSocket(`ws://${host}:${port}?key=${apiKey}`);
       wsRef.current = ws;
 
       const connectionTimeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- secure API requests and WebSocket connections using an API key
- store API key in settings
- expose API key field in settings modal
- send API key in client requests

## Testing
- `npm run format`
- `npm run lint` *(warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d5ba94ec0832594c73346c35330d8