### PR TITLE
Add store-related unit tests

### DIFF
--- a/src/logStore.test.ts
+++ b/src/logStore.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => ({}),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+let useStore: typeof import('./store').useStore;
+let useLogStore: typeof import('./logStore').useLogStore;
+
+type StoreState = ReturnType<typeof useStore.getState>;
+
+let initialMain: StoreState;
+let initialLogs: ReturnType<typeof import('./logStore').useLogStore.getState>;
+
+describe('useLogStore', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const storeMod = await import('./store');
+    const logMod = await import('./logStore');
+    useStore = storeMod.useStore;
+    useLogStore = logMod.useLogStore;
+    initialMain = useStore.getState();
+    initialLogs = useLogStore.getState();
+    useStore.setState(initialMain, true);
+    useLogStore.setState(initialLogs, true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('addMessage respects the logLimit setting', () => {
+    useStore.getState().setLogLimit(2);
+    const add = useLogStore.getState().addMessage;
+    add({ direction: 'in', message: [1], timestamp: 1 });
+    add({ direction: 'in', message: [2], timestamp: 2 });
+    add({ direction: 'in', message: [3], timestamp: 3 });
+    const logs = useLogStore.getState().logs;
+    expect(logs).toHaveLength(2);
+    expect(logs[0].message).toEqual([2]);
+    expect(logs[1].message).toEqual([3]);
+  });
+});

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => ({}),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+let useStore: typeof import('./store').useStore;
+
+describe('useStore actions', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('./store');
+    useStore = mod.useStore;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reorderMacro moves macros and ignores invalid indexes', () => {
+    const { addMacro, reorderMacro } = useStore.getState();
+    addMacro({ id: '1', name: 'one' });
+    addMacro({ id: '2', name: 'two' });
+    addMacro({ id: '3', name: 'three' });
+
+    reorderMacro(0, 2);
+    expect(useStore.getState().macros.map((m) => m.id)).toEqual([
+      '2',
+      '3',
+      '1',
+    ]);
+
+    reorderMacro(3, 0);
+    expect(useStore.getState().macros.map((m) => m.id)).toEqual([
+      '2',
+      '3',
+      '1',
+    ]);
+  });
+
+  it('setReconnectInterval enforces minimum value', () => {
+    useStore.getState().setReconnectInterval(500);
+    expect(useStore.getState().settings.reconnectInterval).toBe(1000);
+
+    useStore.getState().setReconnectInterval(1500);
+    expect(useStore.getState().settings.reconnectInterval).toBe(1500);
+  });
+
+  it('setMaxReconnectAttempts enforces bounds', () => {
+    useStore.getState().setMaxReconnectAttempts(0);
+    expect(useStore.getState().settings.maxReconnectAttempts).toBe(1);
+
+    useStore.getState().setMaxReconnectAttempts(150);
+    expect(useStore.getState().settings.maxReconnectAttempts).toBe(99);
+
+    useStore.getState().setMaxReconnectAttempts(50);
+    expect(useStore.getState().settings.maxReconnectAttempts).toBe(50);
+  });
+});

--- a/src/toastStore.test.ts
+++ b/src/toastStore.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let useToastStore: typeof import('./toastStore').useToastStore;
+let initialState: ReturnType<
+  typeof import('./toastStore').useToastStore.getState
+>;
+
+describe('useToastStore', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const mod = await import('./toastStore');
+    useToastStore = mod.useToastStore;
+    initialState = useToastStore.getState();
+    useToastStore.setState(initialState, true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('limits the number of toasts to five', () => {
+    const add = useToastStore.getState().addToast;
+    for (let i = 0; i < 6; i++) {
+      add(`msg${i}`, 'success');
+    }
+    expect(useToastStore.getState().toasts).toHaveLength(5);
+  });
+
+  it('removes toasts after the timeout', () => {
+    const add = useToastStore.getState().addToast;
+    add('hello', 'success');
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(4000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Zustand stores
- verify macro reordering and settings bounds
- ensure logStore respects log limits
- check toastStore caps toasts and cleans up after timeout

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686ee7980adc8325936485c789238f30