### PR TITLE
Move command validation to module and add tests

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -7,6 +7,8 @@ const cors = require('cors');
 const { exec, spawn } = require('child_process');
 const crypto = require('crypto');
 
+const { isValidCmd } = require('./validate.js');
+
 const API_KEY = process.env.API_KEY || crypto.randomBytes(16).toString('hex');
 console.log('API key:', API_KEY);
 
@@ -14,13 +16,6 @@ const allowedCmds = (process.env.ALLOWED_CMDS || '')
   .split(',')
   .map((c) => c.trim())
   .filter(Boolean);
-
-function isValidCmd(cmd) {
-  if (typeof cmd !== 'string' || !cmd.trim()) return false;
-  if (/[;&|<>`$]/.test(cmd)) return false;
-  const base = cmd.trim().split(/\s+/)[0];
-  return allowedCmds.includes(base);
-}
 
 const app = express();
 app.use(express.json());
@@ -129,7 +124,7 @@ WebMidi.enable({ sysex: true })
         res.status(400).json({ error: 'app path required' });
         return;
       }
-      if (!isValidCmd(appPath)) {
+      if (!isValidCmd(appPath, allowedCmds)) {
         res.status(403).json({ error: 'command not allowed' });
         return;
       }
@@ -150,7 +145,7 @@ WebMidi.enable({ sysex: true })
         res.status(400).json({ error: 'cmd required' });
         return;
       }
-      if (!isValidCmd(cmd)) {
+      if (!isValidCmd(cmd, allowedCmds)) {
         res.status(403).json({ error: 'command not allowed' });
         return;
       }
@@ -171,7 +166,7 @@ WebMidi.enable({ sysex: true })
         res.status(400).json({ error: 'cmd required' });
         return;
       }
-      if (!isValidCmd(cmd)) {
+      if (!isValidCmd(cmd, allowedCmds)) {
         res.status(403).json({ error: 'command not allowed' });
         return;
       }
@@ -196,7 +191,7 @@ WebMidi.enable({ sysex: true })
         res.status(400).json({ error: 'cmd required' });
         return;
       }
-      if (!isValidCmd(cmd)) {
+      if (!isValidCmd(cmd, allowedCmds)) {
         res.status(403).json({ error: 'command not allowed' });
         return;
       }

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/server/validate.js
+++ b/server/validate.js
@@ -1,0 +1,8 @@
+function isValidCmd(cmd, allowedCmds) {
+  if (typeof cmd !== 'string' || !cmd.trim()) return false;
+  if (/[;&|<>`$]/.test(cmd)) return false;
+  const base = cmd.trim().split(/\s+/)[0];
+  return Array.isArray(allowedCmds) && allowedCmds.includes(base);
+}
+
+module.exports = { isValidCmd };

--- a/server/validate.test.ts
+++ b/server/validate.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import validate from './validate.js';
+
+const { isValidCmd } = validate;
+
+const allowed = ['echo', 'ls', 'cat'];
+
+describe('isValidCmd', () => {
+  it('allows whitelisted commands', () => {
+    expect(isValidCmd('echo hello', allowed)).toBe(true);
+    expect(isValidCmd('ls -la', allowed)).toBe(true);
+  });
+
+  it('blocks unlisted commands', () => {
+    expect(isValidCmd('rm -rf /', allowed)).toBe(false);
+  });
+
+  it('blocks commands with dangerous characters', () => {
+    expect(isValidCmd('echo hello && rm -rf /', allowed)).toBe(false);
+    expect(isValidCmd('ls; rm -rf /', allowed)).toBe(false);
+    expect(isValidCmd('cat foo | grep bar', allowed)).toBe(false);
+  });
+
+  it('returns false for non-string or empty input', () => {
+    // @ts-expect-error testing invalid type
+    expect(isValidCmd(null, allowed)).toBe(false);
+    expect(isValidCmd('', allowed)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extract `isValidCmd` helper into `server/validate.js`
- import the validator in `server/index.cjs`
- add `server/package.json` so `.js` files remain CommonJS
- create unit tests for validation logic

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run test` *(then `CTRL+C` to exit watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_686ee793952483258dd602b6030225dd