### PR TITLE
Add component tests

### DIFF
--- a/src/__tests__/LaunchpadCanvas.test.tsx
+++ b/src/__tests__/LaunchpadCanvas.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import LaunchpadCanvas from '../LaunchpadCanvas';
+import { renderWithStore, resetStores } from './testUtils';
+import { useStore } from '../store';
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => ({}),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+describe('LaunchpadCanvas', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it('opens pad options and updates label', async () => {
+    renderWithStore(<LaunchpadCanvas />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTitle('Note 81'));
+    expect(screen.getByText('PAD n-81')).toBeInTheDocument();
+
+    const labelInput = screen.getByPlaceholderText('Label');
+    await user.type(labelInput, 'Hi');
+    expect(useStore.getState().padLabels['n-81']).toBe('Hi');
+
+    await user.click(screen.getByText('CLOSE'));
+    expect(screen.queryByText('PAD n-81')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/MacroBuilder.test.tsx
+++ b/src/__tests__/MacroBuilder.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import MacroBuilder from '../MacroBuilder';
+import { renderWithStore, resetStores } from './testUtils';
+import { useStore } from '../store';
+import { useToastStore } from '../toastStore';
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => ({}),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+describe('MacroBuilder', () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it('saves a new macro and shows a toast', async () => {
+    renderWithStore(<MacroBuilder />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText('Macro name'), 'My Macro');
+    await user.type(screen.getByPlaceholderText('Key sequence'), 'A B');
+    await user.click(screen.getByText('SAVE'));
+
+    const macros = useStore.getState().macros;
+    expect(macros).toHaveLength(1);
+    expect(macros[0].name).toBe('My Macro');
+    expect(useToastStore.getState().toasts[0].message).toBe('Macro saved');
+  });
+});

--- a/src/__tests__/MacroList.test.tsx
+++ b/src/__tests__/MacroList.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import MacroList from '../MacroList';
+import { renderWithStore, resetStores } from './testUtils';
+import { useStore } from '../store';
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => ({}),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+describe('MacroList', () => {
+  beforeEach(() => {
+    resetStores();
+    useStore.setState(
+      (s) => ({
+        ...s,
+        macros: [
+          {
+            id: '1',
+            name: 'One',
+            sequence: ['a'],
+            interval: 10,
+            tags: ['foo'],
+          },
+          {
+            id: '2',
+            name: 'Two',
+            sequence: ['b'],
+            interval: 10,
+            tags: ['bar'],
+          },
+        ],
+      }),
+      true,
+    );
+  });
+
+  it('filters by tag and deletes a macro', async () => {
+    renderWithStore(<MacroList />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText('filter tag'), 'foo');
+    expect(screen.getByText('One')).toBeInTheDocument();
+    expect(screen.queryByText('Two')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('DEL'));
+    expect(useStore.getState().macros).toHaveLength(1);
+  });
+});

--- a/src/__tests__/testUtils.tsx
+++ b/src/__tests__/testUtils.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { useStore } from '../store';
+import { useToastStore } from '../toastStore';
+
+const initialMain = useStore.getState();
+const initialToast = useToastStore.getState();
+
+export function resetStores() {
+  useStore.setState(initialMain, true);
+  useToastStore.setState(initialToast, true);
+}
+
+export function renderWithStore(ui: React.ReactElement) {
+  return render(ui);
+}
+
+export function wrapper({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
   },
 });


### PR DESCRIPTION
## Summary
- add @testing-library utilities
- configure Vitest setup to use `jest-dom`
- add tests for `MacroBuilder`, `MacroList`, and `LaunchpadCanvas`

## Testing
- `npm run lint`
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_686eeb6e93f48325839b148dd2adba88