### PR TITLE
Add Jest setup and shell route tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/server/__tests__/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,12 @@
     "@vitest/ui": "^3.2.4",
     "jsdom": "^26.1.0",
     "@testing-library/react": "^16.3.0",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "@types/jest": "^29.5.8",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.3",
+    "@types/supertest": "^2.0.12",
+    "@types/express": "^4.17.21"
   }
 }

--- a/server/__tests__/shellRoutes.test.ts
+++ b/server/__tests__/shellRoutes.test.ts
@@ -1,0 +1,89 @@
+import request from 'supertest';
+import type { Express } from 'express';
+
+jest.mock('child_process', () => ({
+  exec: jest.fn(
+    (_cmd: string, optsOrCb?: unknown, cb?: (err: unknown) => void) => {
+      const callback =
+        typeof optsOrCb === 'function'
+          ? optsOrCb
+          : (cb as (err: unknown) => void);
+      if (callback) callback(null);
+    },
+  ),
+  spawn: jest.fn(() => ({ unref: jest.fn() })),
+}));
+
+describe('shell routes', () => {
+  const API_KEY = 'test-key';
+  const ALLOW = 'echo,win,app';
+  let app: Express;
+  let exec: jest.Mock;
+  let spawn: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    ({ exec, spawn } = require('child_process'));
+    exec.mockClear();
+    spawn.mockClear();
+    process.env.API_KEY = API_KEY;
+    process.env.ALLOWED_CMDS = ALLOW;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    app = require('../index.cjs');
+  });
+
+  it('executes allowed commands', async () => {
+    await request(app)
+      .post('/run/app')
+      .set('x-api-key', API_KEY)
+      .send({ app: 'app' })
+      .expect(200);
+    expect(exec).toHaveBeenCalledWith('"app"', expect.any(Function));
+
+    await request(app)
+      .post('/run/shell')
+      .set('x-api-key', API_KEY)
+      .send({ cmd: 'echo hi' })
+      .expect(200);
+    expect(exec).toHaveBeenCalledWith('echo hi', expect.any(Function));
+
+    await request(app)
+      .post('/run/shellWin')
+      .set('x-api-key', API_KEY)
+      .send({ cmd: 'win something' })
+      .expect(200);
+    expect(spawn).toHaveBeenCalledWith('win something', {
+      shell: true,
+      detached: true,
+      windowsHide: false,
+    });
+
+    await request(app)
+      .post('/run/shellBg')
+      .set('x-api-key', API_KEY)
+      .send({ cmd: 'echo hi' })
+      .expect(200);
+    expect(exec).toHaveBeenCalledWith(
+      'echo hi',
+      { windowsHide: true },
+      expect.any(Function),
+    );
+  });
+
+  it('rejects disallowed commands', async () => {
+    await request(app)
+      .post('/run/shell')
+      .set('x-api-key', API_KEY)
+      .send({ cmd: 'rm -rf /' })
+      .expect(403);
+    expect(exec).not.toHaveBeenCalled();
+
+    await request(app)
+      .post('/run/shellWin')
+      .set('x-api-key', API_KEY)
+      .send({ cmd: 'malicious' })
+      .expect(403);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "verbatimModuleSyntax": false,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest and supertest
- refactor server to export the Express app without starting the server when imported
- add unit tests covering shell command routes

## Testing
- `npm run format`
- `npm run lint`
- `npm run build` *(fails: Type 'Timeout' is not assignable to type 'number')*
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686eeb68f5d483259504972e0a4125dc