### PR TITLE
Add WebSocket reconnection tests

### DIFF
--- a/src/__tests__/useMidi.test.ts
+++ b/src/__tests__/useMidi.test.ts
@@ -1,0 +1,149 @@
+import { renderHook, act } from '@testing-library/react';
+import { useMidi } from '../useMidi';
+
+// Mock store to supply settings
+interface StoreState {
+  devices: { outputId: string | null };
+  settings: {
+    host: string;
+    port: number;
+    apiKey: string;
+    autoReconnect: boolean;
+    reconnectInterval: number;
+    maxReconnectAttempts: number;
+    pingInterval: number;
+    pingEnabled: boolean;
+  };
+}
+
+let storeState: StoreState;
+jest.mock('../store', () => ({
+  useStore: <T>(selector: (s: StoreState) => T): T => selector(storeState),
+}));
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  public readyState = MockWebSocket.CONNECTING;
+  public onopen: (() => void) | null = null;
+  public onclose: ((ev?: { code?: number }) => void) | null = null;
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+  public onerror: ((ev?: unknown) => void) | null = null;
+  public sent: string[] = [];
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({});
+  }
+
+  // helpers for tests
+  triggerOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  triggerClose(ev: { code?: number } = {}) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(ev);
+  }
+
+  triggerMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+}
+
+global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+describe('useMidi reconnect logic', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    MockWebSocket.instances.length = 0;
+    storeState = {
+      devices: { outputId: null },
+      settings: {
+        host: 'localhost',
+        port: 3000,
+        apiKey: '',
+        autoReconnect: true,
+        reconnectInterval: 1000,
+        maxReconnectAttempts: 2,
+        pingInterval: 1000,
+        pingEnabled: true,
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reconnects after failure with expected delay', () => {
+    const { result } = renderHook(() => useMidi());
+
+    act(() => {
+      window.dispatchEvent(new Event('load'));
+    });
+
+    jest.advanceTimersByTime(100);
+    expect(MockWebSocket.instances.length).toBe(1);
+    const first = MockWebSocket.instances[0];
+
+    act(() => {
+      first.triggerClose({ code: 1006 });
+    });
+
+    jest.advanceTimersByTime(999);
+    expect(MockWebSocket.instances.length).toBe(1);
+    jest.advanceTimersByTime(1);
+    expect(MockWebSocket.instances.length).toBe(2);
+
+    const second = MockWebSocket.instances[1];
+    act(() => {
+      second.triggerClose({ code: 1006 });
+    });
+
+    jest.advanceTimersByTime(2000);
+    // maxReconnectAttempts reached, no new connection
+    expect(MockWebSocket.instances.length).toBe(2);
+    expect(result.current.status).toBe('closed');
+  });
+
+  it('calculates pingDelay from pong messages', () => {
+    renderHook(() => useMidi());
+
+    act(() => {
+      window.dispatchEvent(new Event('load'));
+    });
+
+    jest.advanceTimersByTime(100);
+    const ws = MockWebSocket.instances[0];
+
+    act(() => {
+      ws.triggerOpen();
+    });
+
+    const sent = JSON.parse(ws.sent[0]);
+    const ts = sent.ts;
+
+    jest.advanceTimersByTime(50);
+    act(() => {
+      ws.triggerMessage(JSON.stringify({ type: 'pong', ts }));
+    });
+
+    expect(ws.sent.length).toBe(1);
+    expect(ts).toBeDefined();
+    expect(ts + 50).toBe(Date.now());
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,5 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## Summary
- add new Jest test to verify WebSocket reconnection and ping delay
- exclude tests from TS build

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686eeb6c63a48325b7bb1e5b0edeb4b7