### PR TITLE
Refactor MIDI connection logic

### DIFF
--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useStore } from './store';
+import { useMidiConnection, type RawMessage } from './useMidiConnection';
 
 export interface MidiDevice {
   id: number;
@@ -19,321 +20,29 @@ export interface MidiMessage {
 }
 
 export function useMidi() {
-  const host = useStore((s) => s.settings.host);
-  const port = useStore((s) => s.settings.port);
-  const apiKey = useStore((s) => s.settings.apiKey);
-  const autoReconnect = useStore((s) => s.settings.autoReconnect);
-  const reconnectInterval = useStore((s) => s.settings.reconnectInterval);
-  const maxReconnectAttempts = useStore((s) => s.settings.maxReconnectAttempts);
-  const pingIntervalSetting = useStore((s) => s.settings.pingInterval);
-  const pingEnabled = useStore((s) => s.settings.pingEnabled);
   const selectedOutput = useStore((s) => s.devices.outputId);
+  const {
+    status,
+    pingDelay,
+    send: sendRaw,
+    listen: listenRaw,
+    reconnect,
+  } = useMidiConnection();
+
   const [inputs, setInputs] = useState<MidiDevice[]>([]);
   const [outputs, setOutputs] = useState<MidiDevice[]>([]);
-  const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>(
-    'closed',
-  );
-  const [pingDelay, setPingDelay] = useState<number | null>(null);
   const launchpadRef = useRef<number | null>(null);
   const listeners = useRef(new Set<(msg: MidiMessage) => void>());
-  const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const pingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pingSentAtRef = useRef<number | null>(null);
-  const isPageLoadedRef = useRef(false);
-  const connectionAttemptsRef = useRef(0);
-
-  // Reset ping delay when disabled
-  useEffect(() => {
-    if (!pingEnabled) setPingDelay(null);
-  }, [pingEnabled]);
-
-  const sendPing = useCallback(() => {
-    if (
-      pingEnabled &&
-      wsRef.current &&
-      wsRef.current.readyState === WebSocket.OPEN &&
-      pingSentAtRef.current === null
-    ) {
-      pingSentAtRef.current = Date.now();
-      wsRef.current.send(
-        JSON.stringify({ type: 'ping', ts: pingSentAtRef.current }),
-      );
-    }
-  }, [pingEnabled]);
-
-  // Wait for page to fully load before connecting
-  useEffect(() => {
-    const handleLoad = () => {
-      isPageLoadedRef.current = true;
-      console.log('Page fully loaded, ready to connect WebSocket');
-    };
-
-    if (document.readyState === 'complete') {
-      isPageLoadedRef.current = true;
-      console.log('Page already loaded');
-    } else {
-      window.addEventListener('load', handleLoad);
-      return () => window.removeEventListener('load', handleLoad);
-    }
-  }, []);
-
-  const connectWebSocket = useCallback(() => {
-    if (!isPageLoadedRef.current) {
-      console.log('Page not fully loaded yet, waiting...');
-      return;
-    }
-
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      console.log('WebSocket already connected');
-      return;
-    }
-
-    // Close existing connection if any
-    if (wsRef.current) {
-      wsRef.current.close();
-    }
-
-    console.log(
-      `Attempting WebSocket connection to ws://${host}:${port}?key=${apiKey} (attempt ${connectionAttemptsRef.current + 1})`,
-    );
-    setStatus('connecting');
-
-    try {
-      const ws = new WebSocket(`ws://${host}:${port}?key=${apiKey}`);
-      wsRef.current = ws;
-
-      const connectionTimeout = setTimeout(() => {
-        if (ws.readyState === WebSocket.CONNECTING) {
-          console.log('Connection timeout, closing WebSocket');
-          ws.close();
-        }
-      }, 5000); // 5 second timeout
-
-      ws.onopen = () => {
-        clearTimeout(connectionTimeout);
-        console.log('WebSocket connected successfully');
-        setStatus('connected');
-        connectionAttemptsRef.current = 0; // Reset attempts on successful connection
-
-        // Start ping interval if enabled
-        if (pingIntervalRef.current) clearInterval(pingIntervalRef.current);
-        if (pingEnabled) {
-          sendPing();
-          pingIntervalRef.current = setInterval(sendPing, pingIntervalSetting);
-        }
-
-        // Request device list
-        ws.send(JSON.stringify({ type: 'getDevices' }));
-
-        // Clear any pending reconnect
-        if (reconnectTimeoutRef.current) {
-          clearTimeout(reconnectTimeoutRef.current);
-          reconnectTimeoutRef.current = null;
-        }
-      };
-
-      ws.onmessage = (ev) => {
-        try {
-          const payload = JSON.parse(ev.data);
-
-          if (payload.type === 'pong' && typeof payload.ts === 'number') {
-            if (pingSentAtRef.current !== null) {
-              setPingDelay(Date.now() - payload.ts);
-              pingSentAtRef.current = null;
-            }
-            return;
-          }
-
-          if (payload.type === 'devices') {
-            console.log('Received device list:', payload);
-            setInputs(payload.inputs || []);
-            setOutputs(payload.outputs || []);
-
-            // Find Launchpad X
-            const launchpad = payload.outputs?.find((o: MidiDevice) =>
-              o.name?.toLowerCase().includes('launchpad x'),
-            );
-            launchpadRef.current = launchpad ? launchpad.id : null;
-            if (launchpad) {
-              console.log('Launchpad X detected:', launchpad);
-            }
-          } else if (payload.type === 'midi') {
-            const msg: MidiMessage = {
-              direction: payload.direction || 'in',
-              message: payload.message || [],
-              timestamp: payload.timestamp || Date.now(),
-              source: payload.source,
-              target: payload.target,
-              port: payload.port,
-              pressure: payload.pressure,
-            };
-
-            for (const fn of listeners.current) {
-              fn(msg);
-            }
-          }
-        } catch (err) {
-          console.error('WebSocket message parse error:', err);
-        }
-      };
-
-      ws.onclose = (event) => {
-        clearTimeout(connectionTimeout);
-        console.log('WebSocket disconnected:', event.code, event.reason);
-        setStatus('closed');
-        if (pingIntervalRef.current) {
-          clearInterval(pingIntervalRef.current);
-          pingIntervalRef.current = null;
-        }
-        pingSentAtRef.current = null;
-
-        // Auto-reconnect if enabled and not too many attempts
-        if (
-          autoReconnect &&
-          connectionAttemptsRef.current < maxReconnectAttempts &&
-          !reconnectTimeoutRef.current
-        ) {
-          connectionAttemptsRef.current++;
-          const delay = Math.min(
-            reconnectInterval * connectionAttemptsRef.current,
-            30000,
-          ); // Max 30s delay
-          console.log(
-            `Reconnecting in ${delay}ms... (attempt ${connectionAttemptsRef.current}/${maxReconnectAttempts})`,
-          );
-
-          reconnectTimeoutRef.current = setTimeout(() => {
-            reconnectTimeoutRef.current = null;
-            connectWebSocket();
-          }, delay);
-        } else if (connectionAttemptsRef.current >= maxReconnectAttempts) {
-          console.log('Max reconnection attempts reached');
-        }
-      };
-
-      ws.onerror = (err) => {
-        clearTimeout(connectionTimeout);
-        console.error('WebSocket error:', err);
-        setStatus('closed');
-        if (pingIntervalRef.current) {
-          clearInterval(pingIntervalRef.current);
-          pingIntervalRef.current = null;
-        }
-        pingSentAtRef.current = null;
-      };
-    } catch (err) {
-      console.error('Failed to create WebSocket:', err);
-      setStatus('closed');
-    }
-  }, [
-    host,
-    port,
-    autoReconnect,
-    reconnectInterval,
-    maxReconnectAttempts,
-    pingIntervalSetting,
-    pingEnabled,
-    sendPing,
-  ]);
-
-  // Manual reconnect function
-  const reconnect = useCallback(() => {
-    console.log('Manual reconnect triggered');
-    connectionAttemptsRef.current = 0; // Reset attempts for manual reconnect
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    connectWebSocket();
-  }, [connectWebSocket]);
-
-  // Initial connection when page is loaded
-  useEffect(() => {
-    if (isPageLoadedRef.current) {
-      // Small delay to ensure everything is ready
-      setTimeout(connectWebSocket, 100);
-    }
-  }, [connectWebSocket]);
-
-  // Reconnect when settings change
-  useEffect(() => {
-    if (isPageLoadedRef.current && status !== 'connecting') {
-      console.log('Settings changed, reconnecting...');
-      connectionAttemptsRef.current = 0;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-        reconnectTimeoutRef.current = null;
-      }
-      setTimeout(connectWebSocket, 100);
-    }
-  }, [host, port]);
-
-  // Update ping interval when setting changes
-  useEffect(() => {
-    if (status === 'connected' && wsRef.current) {
-      if (pingIntervalRef.current) clearInterval(pingIntervalRef.current);
-      if (pingEnabled) {
-        pingIntervalRef.current = setInterval(sendPing, pingIntervalSetting);
-      }
-    }
-  }, [pingIntervalSetting, pingEnabled, status, sendPing]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
-      if (pingIntervalRef.current) {
-        clearInterval(pingIntervalRef.current);
-      }
-      pingSentAtRef.current = null;
-      if (wsRef.current) {
-        wsRef.current.close();
-      }
-    };
-  }, []);
 
   const send = useCallback(
     (bytes: number[] | Uint8Array) => {
-      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
-        console.warn(
-          'Cannot send MIDI: WebSocket not connected (status:',
-          status,
-          ')',
-        );
-        return false;
-      }
-
-      // Use selected output device, fallback to Launchpad X, then default to 0
       const targetPort = selectedOutput
         ? Number(selectedOutput)
-        : launchpadRef.current !== null
-          ? launchpadRef.current
-          : 0;
-
+        : (launchpadRef.current ?? 0);
       const bytesArray = Array.from(bytes);
-
-      console.log('Sending MIDI to port', targetPort, ':', bytesArray);
-
-      try {
-        wsRef.current.send(
-          JSON.stringify({
-            type: 'send',
-            port: targetPort,
-            bytes: bytesArray,
-          }),
-        );
-        return true;
-      } catch (err) {
-        console.error('Failed to send MIDI:', err);
-        return false;
-      }
+      return sendRaw({ type: 'send', port: targetPort, bytes: bytesArray });
     },
-    [selectedOutput, status],
+    [selectedOutput, sendRaw],
   );
 
   const listen = useCallback((handler: (msg: MidiMessage) => void) => {
@@ -343,15 +52,51 @@ export function useMidi() {
     };
   }, []);
 
-  // Auto-enter programmer mode when Launchpad X is detected
+  useEffect(() => {
+    const unsub = listenRaw((payload: RawMessage) => {
+      if (payload.type === 'devices') {
+        const dev = payload as {
+          inputs?: MidiDevice[];
+          outputs?: MidiDevice[];
+        };
+        setInputs(dev.inputs || []);
+        setOutputs(dev.outputs || []);
+        const launchpad = dev.outputs?.find((o: MidiDevice) =>
+          o.name?.toLowerCase().includes('launchpad x'),
+        );
+        launchpadRef.current = launchpad ? launchpad.id : null;
+      } else if (payload.type === 'midi') {
+        const midi = payload as {
+          direction?: 'in' | 'out';
+          message?: number[];
+          timestamp?: number;
+          source?: string;
+          target?: string;
+          port?: number;
+          pressure?: number;
+        };
+        const msg: MidiMessage = {
+          direction: midi.direction || 'in',
+          message: midi.message || [],
+          timestamp: midi.timestamp || Date.now(),
+          source: midi.source,
+          target: midi.target,
+          port: midi.port,
+          pressure: midi.pressure,
+        };
+        for (const fn of listeners.current) fn(msg);
+      }
+    });
+    return unsub;
+  }, [listenRaw]);
+
   useEffect(() => {
     if (launchpadRef.current !== null && status === 'connected') {
-      console.log('Auto-entering programmer mode for Launchpad X');
       setTimeout(() => {
         send([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x01, 0xf7]);
       }, 1000);
     }
-  }, [launchpadRef.current, status, send]);
+  }, [status, send]);
 
   return {
     inputs,

--- a/src/useMidiConnection.ts
+++ b/src/useMidiConnection.ts
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from './store';
+import { usePing } from './usePing';
+
+export type RawMessage = Record<string, unknown>;
+export type RawListener = (msg: RawMessage) => void;
+
+export function useMidiConnection() {
+  const host = useStore((s) => s.settings.host);
+  const port = useStore((s) => s.settings.port);
+  const apiKey = useStore((s) => s.settings.apiKey);
+  const autoReconnect = useStore((s) => s.settings.autoReconnect);
+  const reconnectInterval = useStore((s) => s.settings.reconnectInterval);
+  const maxReconnectAttempts = useStore((s) => s.settings.maxReconnectAttempts);
+  const pingInterval = useStore((s) => s.settings.pingInterval);
+  const pingEnabled = useStore((s) => s.settings.pingEnabled);
+
+  const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>(
+    'closed',
+  );
+  const wsRef = useRef<WebSocket | null>(null);
+  const listeners = useRef(new Set<RawListener>());
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const connectionAttemptsRef = useRef(0);
+  const isPageLoadedRef = useRef(false);
+
+  const {
+    pingDelay,
+    handlePong,
+    start: startPing,
+    stop: stopPing,
+  } = usePing(wsRef, pingEnabled, pingInterval);
+
+  // Reset ping delay when disabled
+  useEffect(() => {
+    if (!pingEnabled) stopPing();
+  }, [pingEnabled, stopPing]);
+
+  // Wait for page to fully load before connecting
+  useEffect(() => {
+    const handleLoad = () => {
+      isPageLoadedRef.current = true;
+    };
+
+    if (document.readyState === 'complete') {
+      isPageLoadedRef.current = true;
+    } else {
+      window.addEventListener('load', handleLoad);
+      return () => window.removeEventListener('load', handleLoad);
+    }
+  }, []);
+
+  const connectWebSocket = useCallback(() => {
+    if (!isPageLoadedRef.current) return;
+
+    if (wsRef.current?.readyState === WebSocket.OPEN) return;
+
+    if (wsRef.current) {
+      wsRef.current.close();
+    }
+
+    setStatus('connecting');
+
+    try {
+      const ws = new WebSocket(`ws://${host}:${port}?key=${apiKey}`);
+      wsRef.current = ws;
+
+      const connectionTimeout = setTimeout(() => {
+        if (ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+      }, 5000);
+
+      ws.onopen = () => {
+        clearTimeout(connectionTimeout);
+        setStatus('connected');
+        connectionAttemptsRef.current = 0;
+        startPing();
+        ws.send(JSON.stringify({ type: 'getDevices' }));
+        if (reconnectTimeoutRef.current) {
+          clearTimeout(reconnectTimeoutRef.current);
+          reconnectTimeoutRef.current = null;
+        }
+      };
+
+      const handleClose = () => {
+        clearTimeout(connectionTimeout);
+        setStatus('closed');
+        stopPing();
+        if (
+          autoReconnect &&
+          connectionAttemptsRef.current < maxReconnectAttempts &&
+          !reconnectTimeoutRef.current
+        ) {
+          connectionAttemptsRef.current++;
+          const delay = Math.min(
+            reconnectInterval * connectionAttemptsRef.current,
+            30000,
+          );
+          reconnectTimeoutRef.current = setTimeout(() => {
+            reconnectTimeoutRef.current = null;
+            connectWebSocket();
+          }, delay);
+        }
+      };
+
+      ws.onclose = handleClose;
+      ws.onerror = handleClose;
+
+      ws.onmessage = (ev) => {
+        try {
+          const payload = JSON.parse(ev.data);
+          if (payload.type === 'pong' && typeof payload.ts === 'number') {
+            handlePong(payload.ts);
+            return;
+          }
+          for (const fn of listeners.current) fn(payload);
+        } catch (err) {
+          console.error('WebSocket message parse error:', err);
+        }
+      };
+    } catch (err) {
+      console.error('Failed to create WebSocket:', err);
+      setStatus('closed');
+    }
+  }, [
+    host,
+    port,
+    apiKey,
+    autoReconnect,
+    reconnectInterval,
+    maxReconnectAttempts,
+    startPing,
+    stopPing,
+    handlePong,
+  ]);
+
+  const reconnect = useCallback(() => {
+    connectionAttemptsRef.current = 0;
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    connectWebSocket();
+  }, [connectWebSocket]);
+
+  useEffect(() => {
+    if (isPageLoadedRef.current) {
+      setTimeout(connectWebSocket, 100);
+    }
+  }, [connectWebSocket]);
+
+  useEffect(() => {
+    if (isPageLoadedRef.current && status !== 'connecting') {
+      connectionAttemptsRef.current = 0;
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      setTimeout(connectWebSocket, 100);
+    }
+  }, [host, port, connectWebSocket, status]);
+
+  useEffect(() => {
+    if (status === 'connected') startPing();
+  }, [pingInterval, pingEnabled, status, startPing]);
+
+  useEffect(() => {
+    return () => {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+      stopPing();
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, [stopPing]);
+
+  const send = useCallback((data: unknown) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN)
+      return false;
+    try {
+      wsRef.current.send(JSON.stringify(data));
+      return true;
+    } catch (err) {
+      console.error('Failed to send', err);
+      return false;
+    }
+  }, []);
+
+  const listen = useCallback((fn: RawListener) => {
+    listeners.current.add(fn);
+    return () => {
+      listeners.current.delete(fn);
+    };
+  }, []);
+
+  return { status, pingDelay, send, listen, reconnect, wsRef };
+}

--- a/src/usePing.ts
+++ b/src/usePing.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function usePing(
+  wsRef: React.RefObject<WebSocket | null>,
+  enabled: boolean,
+  interval: number,
+) {
+  const [pingDelay, setPingDelay] = useState<number | null>(null);
+  const pingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pingSentAtRef = useRef<number | null>(null);
+
+  const sendPing = useCallback(() => {
+    if (
+      enabled &&
+      wsRef.current &&
+      wsRef.current.readyState === WebSocket.OPEN &&
+      pingSentAtRef.current === null
+    ) {
+      pingSentAtRef.current = Date.now();
+      wsRef.current.send(
+        JSON.stringify({ type: 'ping', ts: pingSentAtRef.current }),
+      );
+    }
+  }, [enabled, wsRef]);
+
+  const handlePong = useCallback((ts: number) => {
+    if (pingSentAtRef.current !== null) {
+      setPingDelay(Date.now() - ts);
+      pingSentAtRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    if (pingIntervalRef.current) clearInterval(pingIntervalRef.current);
+    if (enabled) {
+      sendPing();
+      pingIntervalRef.current = setInterval(sendPing, interval);
+    }
+  }, [enabled, interval, sendPing]);
+
+  const stop = useCallback(() => {
+    if (pingIntervalRef.current) {
+      clearInterval(pingIntervalRef.current);
+      pingIntervalRef.current = null;
+    }
+    pingSentAtRef.current = null;
+  }, []);
+
+  useEffect(() => stop, [stop]);
+
+  return { pingDelay, sendPing, handlePong, start, stop };
+}


### PR DESCRIPTION
## Summary
- add `usePing` and `useMidiConnection` hooks
- simplify `useMidi` to delegate socket logic

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: expected 2 but got 4, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ffec67c448325babdfbebd080542e