### PR TITLE
refactor macro REST mapping

### DIFF
--- a/src/macroEndpoints.ts
+++ b/src/macroEndpoints.ts
@@ -1,0 +1,29 @@
+import type { Macro, MacroType } from './store';
+
+export interface MacroEndpoint {
+  url: string;
+  body: (macro: Macro) => Record<string, unknown>;
+}
+
+export const MACRO_ENDPOINTS: Record<MacroType, MacroEndpoint> = {
+  app: {
+    url: '/run/app',
+    body: (m) => ({ app: m.command }),
+  },
+  shell: {
+    url: '/run/shell',
+    body: (m) => ({ cmd: m.command }),
+  },
+  shell_win: {
+    url: '/run/shellWin',
+    body: (m) => ({ cmd: m.command }),
+  },
+  shell_bg: {
+    url: '/run/shellBg',
+    body: (m) => ({ cmd: m.command }),
+  },
+  keys: {
+    url: '/keys/type',
+    body: (m) => ({ sequence: m.sequence, interval: m.interval }),
+  },
+};

--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useStore } from './store';
 import { useToastStore } from './toastStore';
+import { MACRO_ENDPOINTS } from './macroEndpoints';
 
 export function useKeyMacroPlayer() {
   const macros = useStore((s) => s.macros);
@@ -14,55 +15,15 @@ export function useKeyMacroPlayer() {
       console.log('Playing macro', macro);
       addToast(`Playing: ${macro.name}`, 'success');
       try {
-        if (macro.type === 'app') {
-          await fetch('/run/app', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-api-key': apiKey,
-            },
-            body: JSON.stringify({ app: macro.command }),
-          });
-        } else if (macro.type === 'shell') {
-          await fetch('/run/shell', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-api-key': apiKey,
-            },
-            body: JSON.stringify({ cmd: macro.command }),
-          });
-        } else if (macro.type === 'shell_win') {
-          await fetch('/run/shellWin', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-api-key': apiKey,
-            },
-            body: JSON.stringify({ cmd: macro.command }),
-          });
-        } else if (macro.type === 'shell_bg') {
-          await fetch('/run/shellBg', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-api-key': apiKey,
-            },
-            body: JSON.stringify({ cmd: macro.command }),
-          });
-        } else {
-          await fetch('/keys/type', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-api-key': apiKey,
-            },
-            body: JSON.stringify({
-              sequence: macro.sequence,
-              interval: macro.interval,
-            }),
-          });
-        }
+        const { url, body } = MACRO_ENDPOINTS[macro.type || 'keys'];
+        await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': apiKey,
+          },
+          body: JSON.stringify(body(macro)),
+        });
         if (macro.nextId) {
           await playMacro(macro.nextId);
         }


### PR DESCRIPTION
## Summary
- define a `MACRO_ENDPOINTS` map
- use the map to simplify macro execution logic

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: `WebSocket is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_687186194f0c832585dc403f60581558