### PR TITLE
Refactor MIDI connection hooks

### DIFF
--- a/src/useMidiConnection.ts
+++ b/src/useMidiConnection.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useStore } from './store';
 import { usePing } from './usePing';
+import { useWebSocket } from './useWebSocket';
 
 export type RawMessage = Record<string, unknown>;
 export type RawListener = (msg: RawMessage) => void;
@@ -15,16 +16,23 @@ export function useMidiConnection() {
   const pingInterval = useStore((s) => s.settings.pingInterval);
   const pingEnabled = useStore((s) => s.settings.pingEnabled);
 
-  const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>(
-    'closed',
-  );
-  const wsRef = useRef<WebSocket | null>(null);
-  const listeners = useRef(new Set<RawListener>());
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const connectionAttemptsRef = useRef(0);
-  const isPageLoadedRef = useRef(false);
+  const url = `ws://${host}:${port}?key=${apiKey}`;
+
+  const {
+    status,
+    send,
+    listen: wsListen,
+    reconnect,
+    wsRef,
+  } = useWebSocket({
+    url,
+    autoReconnect,
+    reconnectInterval,
+    maxReconnectAttempts,
+    onOpen: (ws) => {
+      ws.send(JSON.stringify({ type: 'getDevices' }));
+    },
+  });
 
   const {
     pingDelay,
@@ -33,170 +41,33 @@ export function useMidiConnection() {
     stop: stopPing,
   } = usePing(wsRef, pingEnabled, pingInterval);
 
-  // Reset ping delay when disabled
+  const listen = useCallback(
+    (fn: RawListener) => wsListen((data) => fn(data as RawMessage)),
+    [wsListen],
+  );
+
   useEffect(() => {
     if (!pingEnabled) stopPing();
   }, [pingEnabled, stopPing]);
 
-  // Wait for page to fully load before connecting
-  useEffect(() => {
-    const handleLoad = () => {
-      isPageLoadedRef.current = true;
-    };
-
-    if (document.readyState === 'complete') {
-      isPageLoadedRef.current = true;
-    } else {
-      window.addEventListener('load', handleLoad);
-      return () => window.removeEventListener('load', handleLoad);
-    }
-  }, []);
-
-  const connectWebSocket = useCallback(() => {
-    if (!isPageLoadedRef.current) return;
-
-    if (wsRef.current?.readyState === WebSocket.OPEN) return;
-
-    if (wsRef.current) {
-      wsRef.current.close();
-    }
-
-    setStatus('connecting');
-
-    try {
-      const ws = new WebSocket(`ws://${host}:${port}?key=${apiKey}`);
-      wsRef.current = ws;
-
-      const connectionTimeout = setTimeout(() => {
-        if (ws.readyState === WebSocket.CONNECTING) {
-          ws.close();
-        }
-      }, 5000);
-
-      ws.onopen = () => {
-        clearTimeout(connectionTimeout);
-        setStatus('connected');
-        connectionAttemptsRef.current = 0;
-        startPing();
-        ws.send(JSON.stringify({ type: 'getDevices' }));
-        if (reconnectTimeoutRef.current) {
-          clearTimeout(reconnectTimeoutRef.current);
-          reconnectTimeoutRef.current = null;
-        }
-      };
-
-      const handleClose = () => {
-        clearTimeout(connectionTimeout);
-        setStatus('closed');
-        stopPing();
-        if (
-          autoReconnect &&
-          connectionAttemptsRef.current < maxReconnectAttempts &&
-          !reconnectTimeoutRef.current
-        ) {
-          connectionAttemptsRef.current++;
-          const delay = Math.min(
-            reconnectInterval * connectionAttemptsRef.current,
-            30000,
-          );
-          reconnectTimeoutRef.current = setTimeout(() => {
-            reconnectTimeoutRef.current = null;
-            connectWebSocket();
-          }, delay);
-        }
-      };
-
-      ws.onclose = handleClose;
-      ws.onerror = handleClose;
-
-      ws.onmessage = (ev) => {
-        try {
-          const payload = JSON.parse(ev.data);
-          if (payload.type === 'pong' && typeof payload.ts === 'number') {
-            handlePong(payload.ts);
-            return;
-          }
-          for (const fn of listeners.current) fn(payload);
-        } catch (err) {
-          console.error('WebSocket message parse error:', err);
-        }
-      };
-    } catch (err) {
-      console.error('Failed to create WebSocket:', err);
-      setStatus('closed');
-    }
-  }, [
-    host,
-    port,
-    apiKey,
-    autoReconnect,
-    reconnectInterval,
-    maxReconnectAttempts,
-    startPing,
-    stopPing,
-    handlePong,
-  ]);
-
-  const reconnect = useCallback(() => {
-    connectionAttemptsRef.current = 0;
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    connectWebSocket();
-  }, [connectWebSocket]);
-
-  useEffect(() => {
-    if (isPageLoadedRef.current) {
-      setTimeout(connectWebSocket, 100);
-    }
-  }, [connectWebSocket]);
-
-  useEffect(() => {
-    if (isPageLoadedRef.current && status !== 'connecting') {
-      connectionAttemptsRef.current = 0;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-        reconnectTimeoutRef.current = null;
-      }
-      setTimeout(connectWebSocket, 100);
-    }
-  }, [host, port, connectWebSocket, status]);
-
   useEffect(() => {
     if (status === 'connected') startPing();
-  }, [pingInterval, pingEnabled, status, startPing]);
+    else stopPing();
+  }, [status, startPing, stopPing]);
 
   useEffect(() => {
-    return () => {
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
+    const unsub = listen((payload: RawMessage) => {
+      if (
+        payload.type === 'pong' &&
+        typeof (payload as { ts?: unknown }).ts === 'number'
+      ) {
+        handlePong((payload as { ts: number }).ts);
       }
-      stopPing();
-      if (wsRef.current) {
-        wsRef.current.close();
-      }
-    };
-  }, [stopPing]);
+    });
+    return unsub;
+  }, [listen, handlePong]);
 
-  const send = useCallback((data: unknown) => {
-    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN)
-      return false;
-    try {
-      wsRef.current.send(JSON.stringify(data));
-      return true;
-    } catch (err) {
-      console.error('Failed to send', err);
-      return false;
-    }
-  }, []);
-
-  const listen = useCallback((fn: RawListener) => {
-    listeners.current.add(fn);
-    return () => {
-      listeners.current.delete(fn);
-    };
-  }, []);
+  useEffect(() => stopPing, [stopPing]);
 
   return { status, pingDelay, send, listen, reconnect, wsRef };
 }

--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type MessageListener = (data: unknown) => void;
+
+export interface UseWebSocketOptions {
+  url: string;
+  autoReconnect?: boolean;
+  reconnectInterval?: number;
+  maxReconnectAttempts?: number;
+  onOpen?: (ws: WebSocket) => void;
+}
+
+export function useWebSocket({
+  url,
+  autoReconnect = true,
+  reconnectInterval = 1000,
+  maxReconnectAttempts = 5,
+  onOpen,
+}: UseWebSocketOptions) {
+  const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>(
+    'closed',
+  );
+  const wsRef = useRef<WebSocket | null>(null);
+  const listeners = useRef(new Set<MessageListener>());
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const connectionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const connectionAttemptsRef = useRef(0);
+  const isPageLoadedRef = useRef(false);
+
+  useEffect(() => {
+    const handleLoad = () => {
+      isPageLoadedRef.current = true;
+    };
+
+    if (document.readyState === 'complete') {
+      isPageLoadedRef.current = true;
+    } else {
+      window.addEventListener('load', handleLoad);
+      return () => window.removeEventListener('load', handleLoad);
+    }
+  }, []);
+
+  const connectWebSocket = useCallback(() => {
+    if (typeof WebSocket === 'undefined') return;
+    if (!isPageLoadedRef.current) return;
+    if (
+      wsRef.current &&
+      (wsRef.current.readyState === WebSocket.OPEN ||
+        wsRef.current.readyState === WebSocket.CONNECTING)
+    )
+      return;
+
+    if (
+      wsRef.current &&
+      (wsRef.current.readyState === WebSocket.OPEN ||
+        wsRef.current.readyState === WebSocket.CONNECTING)
+    ) {
+      wsRef.current.close();
+    }
+
+    setStatus('connecting');
+
+    try {
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+
+      if (connectionTimeoutRef.current)
+        clearTimeout(connectionTimeoutRef.current);
+      connectionTimeoutRef.current = setTimeout(() => {
+        if (ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+      }, 5000);
+
+      ws.onopen = () => {
+        if (connectionTimeoutRef.current) {
+          clearTimeout(connectionTimeoutRef.current);
+          connectionTimeoutRef.current = null;
+        }
+        setStatus('connected');
+        connectionAttemptsRef.current = 0;
+        onOpen?.(ws);
+        if (reconnectTimeoutRef.current) {
+          clearTimeout(reconnectTimeoutRef.current);
+          reconnectTimeoutRef.current = null;
+        }
+      };
+
+      const handleClose = () => {
+        if (connectionTimeoutRef.current) {
+          clearTimeout(connectionTimeoutRef.current);
+          connectionTimeoutRef.current = null;
+        }
+        setStatus('closed');
+        if (
+          autoReconnect &&
+          connectionAttemptsRef.current < maxReconnectAttempts &&
+          !reconnectTimeoutRef.current
+        ) {
+          connectionAttemptsRef.current++;
+          const delay = Math.min(
+            reconnectInterval * connectionAttemptsRef.current,
+            30000,
+          );
+          reconnectTimeoutRef.current = setTimeout(() => {
+            reconnectTimeoutRef.current = null;
+            connectWebSocket();
+          }, delay);
+        }
+      };
+
+      ws.onclose = handleClose;
+      ws.onerror = handleClose;
+
+      ws.onmessage = (ev) => {
+        try {
+          const payload = JSON.parse(ev.data);
+          for (const fn of listeners.current) fn(payload);
+        } catch (err) {
+          console.error('WebSocket message parse error:', err);
+        }
+      };
+    } catch (err) {
+      console.error('Failed to create WebSocket:', err);
+      setStatus('closed');
+    }
+  }, [url, autoReconnect, reconnectInterval, maxReconnectAttempts, onOpen]);
+
+  const reconnect = useCallback(() => {
+    connectionAttemptsRef.current = 0;
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    connectWebSocket();
+  }, [connectWebSocket]);
+
+  useEffect(() => {
+    if (isPageLoadedRef.current) {
+      connectionAttemptsRef.current = 0;
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      setTimeout(connectWebSocket, 100);
+    }
+  }, [url, connectWebSocket]);
+
+  useEffect(() => {
+    return () => {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+      if (connectionTimeoutRef.current) {
+        clearTimeout(connectionTimeoutRef.current);
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, []);
+
+  const send = useCallback((data: unknown) => {
+    if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN)
+      return false;
+    try {
+      wsRef.current.send(JSON.stringify(data));
+      return true;
+    } catch (err) {
+      console.error('Failed to send', err);
+      return false;
+    }
+  }, []);
+
+  const listen = useCallback((fn: MessageListener) => {
+    listeners.current.add(fn);
+    return () => {
+      listeners.current.delete(fn);
+    };
+  }, []);
+
+  return { status, send, listen, reconnect, wsRef };
+}


### PR DESCRIPTION
## Summary
- create `useWebSocket` for generic WebSocket management
- refactor `useMidiConnection` to use the new hook

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: reconnect logic expectations)*

------
https://chatgpt.com/codex/tasks/task_e_6871861c3b5c8325b1213fdaef60250b