### PR TITLE
Fix WebSocket reconnection logic

### DIFF
--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -47,18 +47,14 @@ export function useWebSocket({
   const connectWebSocket = useCallback(() => {
     if (typeof WebSocket === 'undefined') return;
     if (!isPageLoadedRef.current) return;
-    if (
-      wsRef.current &&
-      (wsRef.current.readyState === WebSocket.OPEN ||
-        wsRef.current.readyState === WebSocket.CONNECTING)
-    )
-      return;
 
-    if (
-      wsRef.current &&
-      (wsRef.current.readyState === WebSocket.OPEN ||
-        wsRef.current.readyState === WebSocket.CONNECTING)
-    ) {
+    if (wsRef.current) {
+      if (
+        wsRef.current.readyState === WebSocket.OPEN ||
+        wsRef.current.readyState === WebSocket.CONNECTING
+      ) {
+        return;
+      }
       wsRef.current.close();
     }
 


### PR DESCRIPTION
## Summary
- reconnect cleanly when the previous WebSocket isn't open or connecting

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687199d1d9a883259574e5aaf8200fa2