### PR TITLE
Refactor server commands to WebSocket

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -32,99 +32,6 @@ function checkKey(req, res, next) {
 
 app.use(checkKey);
 
-// Shell command routes are needed in tests and do not rely on WebMidi
-function addShellRoutes() {
-  app.post('/run/app', (req, res) => {
-    const { app: appPath } = req.body || {};
-    console.log('Run app request:', appPath);
-    if (!appPath) {
-      res.status(400).json({ error: 'app path required' });
-      return;
-    }
-    if (!isValidCmd(appPath, allowedCmds)) {
-      res.status(403).json({ error: 'command not allowed' });
-      return;
-    }
-    exec(`"${appPath}"`, (err) => {
-      if (err) {
-        console.error('App exec error:', err);
-        res.status(500).json({ error: err.message });
-      } else {
-        res.json({ ok: true });
-      }
-    });
-  });
-
-  app.post('/run/shell', (req, res) => {
-    const { cmd } = req.body || {};
-    console.log('Run shell request:', cmd);
-    if (!cmd) {
-      res.status(400).json({ error: 'cmd required' });
-      return;
-    }
-    if (!isValidCmd(cmd, allowedCmds)) {
-      res.status(403).json({ error: 'command not allowed' });
-      return;
-    }
-    exec(cmd, (err) => {
-      if (err) {
-        console.error('Shell exec error:', err);
-        res.status(500).json({ error: err.message });
-      } else {
-        res.json({ ok: true });
-      }
-    });
-  });
-
-  app.post('/run/shellWin', (req, res) => {
-    const { cmd } = req.body || {};
-    console.log('Run shellWin request:', cmd);
-    if (!cmd) {
-      res.status(400).json({ error: 'cmd required' });
-      return;
-    }
-    if (!isValidCmd(cmd, allowedCmds)) {
-      res.status(403).json({ error: 'command not allowed' });
-      return;
-    }
-    try {
-      const child = spawn(cmd, {
-        shell: true,
-        detached: true,
-        windowsHide: false,
-      });
-      child.unref();
-      res.json({ ok: true });
-    } catch (err) {
-      console.error('ShellWin spawn error:', err);
-      res.status(500).json({ error: err.message });
-    }
-  });
-
-  app.post('/run/shellBg', (req, res) => {
-    const { cmd } = req.body || {};
-    console.log('Run shellBg request:', cmd);
-    if (!cmd) {
-      res.status(400).json({ error: 'cmd required' });
-      return;
-    }
-    if (!isValidCmd(cmd, allowedCmds)) {
-      res.status(403).json({ error: 'command not allowed' });
-      return;
-    }
-    exec(cmd, { windowsHide: true }, (err) => {
-      if (err) {
-        console.error('ShellBg exec error:', err);
-        res.status(500).json({ error: err.message });
-      } else {
-        res.json({ ok: true });
-      }
-    });
-  });
-}
-
-addShellRoutes();
-
 let currentDevices = { inputs: [], outputs: [] };
 
 async function startServer() {
@@ -409,6 +316,7 @@ async function startServer() {
       setupMidiListeners(); // Re-setup listeners for new devices
       sendDevices(); // Broadcast to all clients
     });
+    return server;
   } catch (err) {
     console.error('Failed to enable WebMidi:', err);
   }
@@ -418,4 +326,4 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = app;
+module.exports = { app, startServer };


### PR DESCRIPTION
## Summary
- remove Express routes for running shell commands
- expose `startServer` and return the HTTP server
- update shell command tests to use WebSocket messages

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: useMidi reconnect logic tests)*

------
https://chatgpt.com/codex/tasks/task_e_68719bfe13088325a07756c6632a49a8