### PR TITLE
Add launchpad color lookup helper

### DIFF
--- a/src/ConfigManager.tsx
+++ b/src/ConfigManager.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useStore, type PadConfig } from './store';
 import { useToastStore } from './toastStore';
 import { useMidi } from './useMidi';
-import LAUNCHPAD_COLORS from './launchpadColors';
+import { getLaunchpadColorValue } from './launchpadColors';
 import {
   enterProgrammerMode,
   clearAllLeds,
@@ -122,7 +122,7 @@ export default function ConfigManager() {
     for (const [id, chMap] of Object.entries(cfg.padColours)) {
       for (const [chStr, hex] of Object.entries(chMap)) {
         const channel = Number(chStr);
-        const color = LAUNCHPAD_COLORS.find((c) => c.color === hex)?.value;
+        const color = getLaunchpadColorValue(hex);
         if (color === undefined) continue;
         const padId = id.startsWith('n-')
           ? Number(id.slice(2))

--- a/src/LaunchpadControls.tsx
+++ b/src/LaunchpadControls.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useMidi } from './useMidi';
 import { useStore } from './store';
 import { useToastStore } from './toastStore';
-import LAUNCHPAD_COLORS from './launchpadColors';
+import { getLaunchpadColorValue } from './launchpadColors';
 import {
   enterProgrammerMode,
   exitProgrammerMode,
@@ -88,7 +88,7 @@ export default function LaunchpadControls() {
     for (const [id, chMap] of Object.entries(padColours)) {
       for (const [chStr, hex] of Object.entries(chMap)) {
         const channel = Number(chStr);
-        const color = LAUNCHPAD_COLORS.find((c) => c.color === hex)?.value;
+        const color = getLaunchpadColorValue(hex);
         if (color === undefined) continue;
         const padId = id.startsWith('n-')
           ? Number(id.slice(2))

--- a/src/launchpadColors.ts
+++ b/src/launchpadColors.ts
@@ -134,4 +134,12 @@ export const LAUNCHPAD_COLORS: LaunchpadColor[] = [
   { name: 'darkolivegreen', value: 0x7e, color: '#544422' },
   { name: 'sienna', value: 0x7f, color: '#925848' },
 ];
+
+export function getLaunchpadColorValue(hex: string): number | undefined {
+  const color = LAUNCHPAD_COLORS.find(
+    (c) => c.color.toLowerCase() === hex.toLowerCase(),
+  );
+  return color?.value;
+}
+
 export default LAUNCHPAD_COLORS;

--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -4,7 +4,7 @@ import { useStore } from './store';
 import { useKeyMacroPlayer } from './useKeyMacroPlayer';
 import { notify } from './notify';
 import { useToastStore } from './toastStore';
-import LAUNCHPAD_COLORS from './launchpadColors';
+import { getLaunchpadColorValue } from './launchpadColors';
 import { noteOn, cc, lightingSysEx } from './midiMessages';
 
 export function usePadActions() {
@@ -22,8 +22,7 @@ export function usePadActions() {
   const sendPadState = (id: string, channel: number) => {
     const colours = padColours[id] || {};
     const colorHex = colours[channel] || colours[1] || '#000000';
-    const colorVal =
-      LAUNCHPAD_COLORS.find((c) => c.color === colorHex)?.value || 0;
+    const colorVal = getLaunchpadColorValue(colorHex) || 0;
     const padId = id.startsWith('n-')
       ? Number(id.slice(2))
       : id.startsWith('cc-')


### PR DESCRIPTION
## Summary
- add `getLaunchpadColorValue` utility to map color hex codes to Launchpad values
- refactor pad config modules to use the new helper

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68723a9b97a883258b8efe02c0b0ef07