### PR TITLE
Refactor server routes to WebSocket-only

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -84,9 +84,10 @@ async function startServer() {
       }
     });
 
+    // Deprecated REST routes retained for backwards compatibility
+    // Prefer using WebSocket messages instead of these endpoints
     app.post('/notify', (req, res) => {
       const { title = 'Automidi', message } = req.body || {};
-      console.log('Notify request:', title, message);
       if (!message) {
         res.status(400).json({ error: 'message is required' });
         return;
@@ -99,7 +100,6 @@ async function startServer() {
 
     app.post('/keys/type', async (req, res) => {
       const { sequence = [], interval = 50 } = req.body || {};
-      console.log('Keys type request:', sequence, interval);
       if (!Array.isArray(sequence)) {
         res.status(400).json({ error: 'sequence must be an array of keys' });
         return;

--- a/src/useMidiConnection.ts
+++ b/src/useMidiConnection.ts
@@ -30,9 +30,6 @@ export function useMidiConnection() {
     autoReconnect,
     reconnectInterval,
     maxReconnectAttempts,
-    onOpen: (ws) => {
-      ws.send(JSON.stringify({ type: 'getDevices' }));
-    },
   });
 
   const {

--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -55,7 +55,9 @@ export function useWebSocket({
       ) {
         return;
       }
-      wsRef.current.close();
+      if (wsRef.current.readyState !== WebSocket.CLOSED) {
+        wsRef.current.close();
+      }
     }
 
     setStatus('connecting');
@@ -63,6 +65,7 @@ export function useWebSocket({
     try {
       const ws = new WebSocket(url);
       wsRef.current = ws;
+      connectionAttemptsRef.current++;
 
       if (connectionTimeoutRef.current)
         clearTimeout(connectionTimeoutRef.current);
@@ -97,7 +100,6 @@ export function useWebSocket({
           connectionAttemptsRef.current < maxReconnectAttempts &&
           !reconnectTimeoutRef.current
         ) {
-          connectionAttemptsRef.current++;
           const delay = Math.min(
             reconnectInterval * connectionAttemptsRef.current,
             30000,


### PR DESCRIPTION
## Summary
- deprecate REST endpoints for notification and keyboard typing
- guard WebSocket reconnect logic so closed sockets don't trigger extra reconnects
- stop sending `getDevices` message on open

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68723f497d208325b74e84122073aa6c