### PR TITLE
Implement macro cycle detection

### DIFF
--- a/src/useKeyMacroPlayer.test.ts
+++ b/src/useKeyMacroPlayer.test.ts
@@ -94,4 +94,27 @@ describe('useKeyMacroPlayer socket messages', () => {
       expect.objectContaining({ type: 'runShell' }),
     );
   });
+
+  it('stops when macros form a cycle', async () => {
+    storeState.macros = [
+      {
+        id: '1',
+        name: 'first',
+        type: 'keys',
+        sequence: ['a'],
+        interval: 10,
+        nextId: '2',
+      },
+      { id: '2', name: 'second', type: 'shell', command: 'ls', nextId: '1' },
+    ];
+    const { result } = renderHook(() => useKeyMacroPlayer());
+    await act(async () => {
+      await result.current.playMacro('1');
+    });
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(addToastMock).toHaveBeenCalledWith(
+      expect.stringContaining('Macro cycle detected'),
+      'error',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- track visited macro IDs during recursive playback
- abort playback and show error toast on cycles
- test macro cycle detection

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: useMidi.test.ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872469a6ec08325ae4977e14eb06bb8