### PR TITLE
Add connectionTimeout option to useWebSocket

### DIFF
--- a/src/useMidiConnection.ts
+++ b/src/useMidiConnection.ts
@@ -30,6 +30,7 @@ export function useMidiConnection() {
     autoReconnect,
     reconnectInterval,
     maxReconnectAttempts,
+    connectionTimeout: 5000,
   });
 
   const {

--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -7,6 +7,7 @@ export interface UseWebSocketOptions {
   autoReconnect?: boolean;
   reconnectInterval?: number;
   maxReconnectAttempts?: number;
+  connectionTimeout?: number;
   onOpen?: (ws: WebSocket) => void;
 }
 
@@ -15,6 +16,7 @@ export function useWebSocket({
   autoReconnect = true,
   reconnectInterval = 1000,
   maxReconnectAttempts = 5,
+  connectionTimeout = 5000,
   onOpen,
 }: UseWebSocketOptions) {
   const [status, setStatus] = useState<'connected' | 'closed' | 'connecting'>(
@@ -73,7 +75,7 @@ export function useWebSocket({
         if (ws.readyState === WebSocket.CONNECTING) {
           ws.close();
         }
-      }, 5000);
+      }, connectionTimeout);
 
       ws.onopen = () => {
         if (connectionTimeoutRef.current) {


### PR DESCRIPTION
## Summary
- allow configuring connectionTimeout in `useWebSocket`
- use the new option in `useMidiConnection`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: useMidi.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_687246ad38548325a8032841559b6b68