### PR TITLE
Guard API key logging in server

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -10,7 +10,11 @@ const crypto = require('crypto');
 const { isValidCmd } = require('./validate.js');
 
 const API_KEY = process.env.API_KEY || crypto.randomBytes(16).toString('hex');
-console.log('API key:', API_KEY);
+if (process.env.LOG_API_KEY === 'true') {
+  console.log('API key:', API_KEY);
+} else {
+  console.log('Server started with API key set.');
+}
 
 const allowedCmds = (process.env.ALLOWED_CMDS || '')
   .split(',')


### PR DESCRIPTION
## Summary
- guard API key log with `LOG_API_KEY` env var
- log a generic message when the API key isn't printed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872527c3de0832593433a1734027cbf