### PR TITLE
Migrate server files to TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+server/dist
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "preview": "vite preview",
-    "server": "node server/index.cjs",
+    "build:server": "tsc -p server/tsconfig.json",
+    "server": "npm run build:server && node server/dist/index.js",
     "setup": "npm install",
     "test": "vitest run"
   },

--- a/server/__tests__/shellRoutes.test.ts
+++ b/server/__tests__/shellRoutes.test.ts
@@ -8,7 +8,7 @@ import {
   type Mock,
 } from 'vitest';
 import WebSocket from 'ws';
-import { isValidCmd } from '../validate.js';
+import { isValidCmd } from '../dist/validate.js';
 import type { Server } from 'http';
 
 describe('shell routes', () => {
@@ -56,7 +56,7 @@ describe('shell routes', () => {
     wm.WebMidi.addListener = vi.fn();
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require('../index.cjs');
+    const mod = require('../dist/index.js');
     server = await mod.startServer();
   });
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "./",
+    "strict": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmitOnError": false,
+    "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.server.tsbuildinfo"
+  },
+  "include": ["index.ts", "validate.ts"],
+  "exclude": ["**/*.test.ts", "__tests__", "dist"]
+}

--- a/server/validate.test.ts
+++ b/server/validate.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import validate from './validate.js';
-
-const { isValidCmd } = validate;
+import { isValidCmd } from './dist/validate.js';
 
 const allowed = ['echo', 'ls', 'cat'];
 

--- a/server/validate.ts
+++ b/server/validate.ts
@@ -1,8 +1,6 @@
-function isValidCmd(cmd, allowedCmds) {
+export function isValidCmd(cmd: string, allowedCmds: string[]): boolean {
   if (typeof cmd !== 'string' || !cmd.trim()) return false;
   if (/[;&|<>`$]/.test(cmd)) return false;
   const base = cmd.trim().split(/\s+/)[0];
   return Array.isArray(allowedCmds) && allowedCmds.includes(base);
 }
-
-module.exports = { isValidCmd };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./server/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
## Summary
- compile server files with tsc
- run server from compiled output
- migrate index.cjs and validate.js to TypeScript
- adjust tests to use compiled server modules

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e49e6d708325892ad9b798342bac