### PR TITLE
Fix lint warning by memoizing pad actions

### DIFF
--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -128,7 +128,14 @@ export function useWebSocket({
       console.error('Failed to create WebSocket:', err);
       setStatus('closed');
     }
-  }, [url, autoReconnect, reconnectInterval, maxReconnectAttempts, onOpen]);
+  }, [
+    url,
+    autoReconnect,
+    reconnectInterval,
+    maxReconnectAttempts,
+    onOpen,
+    connectionTimeout,
+  ]);
 
   const reconnect = useCallback(() => {
     connectionAttemptsRef.current = 0;


### PR DESCRIPTION
## Summary
- memoize `handleMacro` with `useCallback`
- stabilize `sendPadState` and `connectWebSocket`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68743623e66c8325991c9dcac1cbb9a3