### PR TITLE
Fix WebSocket useCallback dependencies

### DIFF
--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -128,7 +128,14 @@ export function useWebSocket({
       console.error('Failed to create WebSocket:', err);
       setStatus('closed');
     }
-  }, [url, autoReconnect, reconnectInterval, maxReconnectAttempts, onOpen]);
+  }, [
+    url,
+    autoReconnect,
+    reconnectInterval,
+    maxReconnectAttempts,
+    onOpen,
+    connectionTimeout,
+  ]);
 
   const reconnect = useCallback(() => {
     connectionAttemptsRef.current = 0;


### PR DESCRIPTION
## Summary
- include `connectionTimeout` in `useWebSocket` dependency list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874362699c4832599fb46894858e7be