### PR TITLE
Fix command validation for quoted cmds

### DIFF
--- a/server/validate.test.ts
+++ b/server/validate.test.ts
@@ -9,6 +9,12 @@ describe('isValidCmd', () => {
     expect(isValidCmd('ls -la', allowed)).toBe(true);
   });
 
+  it('handles quoted commands', () => {
+    expect(isValidCmd('"echo hello"', allowed)).toBe(true);
+    expect(isValidCmd('"ls -la"', allowed)).toBe(true);
+    expect(isValidCmd('"rm -rf /"', allowed)).toBe(false);
+  });
+
   it('blocks unlisted commands', () => {
     expect(isValidCmd('rm -rf /', allowed)).toBe(false);
   });

--- a/server/validate.ts
+++ b/server/validate.ts
@@ -1,6 +1,7 @@
 export function isValidCmd(cmd: string, allowedCmds: string[]): boolean {
   if (typeof cmd !== 'string' || !cmd.trim()) return false;
   if (/[;&|<>`$]/.test(cmd)) return false;
-  const base = cmd.trim().split(/\s+/)[0];
+  const cleaned = cmd.trim().replace(/^"(.*)"$/, '$1');
+  const base = cleaned.split(/\s+/)[0];
   return Array.isArray(allowedCmds) && allowedCmds.includes(base);
 }


### PR DESCRIPTION
## Summary
- handle surrounding quotes in `isValidCmd`
- test command validation with quoted inputs

## Testing
- `npm run build:server`
- `npm test` *(fails: useMidi reconnect logic)*

------
https://chatgpt.com/codex/tasks/task_e_6874f9a70b808325846dbdf6abd0e0a0