### PR TITLE
Fix WebSocket connect on load

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import { globalIgnores } from 'eslint/config';
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'server/dist']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -33,19 +33,6 @@ export function useWebSocket({
   const connectionAttemptsRef = useRef(0);
   const isPageLoadedRef = useRef(false);
 
-  useEffect(() => {
-    const handleLoad = () => {
-      isPageLoadedRef.current = true;
-    };
-
-    if (document.readyState === 'complete') {
-      isPageLoadedRef.current = true;
-    } else {
-      window.addEventListener('load', handleLoad);
-      return () => window.removeEventListener('load', handleLoad);
-    }
-  }, []);
-
   const connectWebSocket = useCallback(() => {
     if (typeof WebSocket === 'undefined') return;
     if (!isPageLoadedRef.current) return;
@@ -136,6 +123,24 @@ export function useWebSocket({
     onOpen,
     connectionTimeout,
   ]);
+
+  useEffect(() => {
+    const handleLoad = () => {
+      isPageLoadedRef.current = true;
+      connectWebSocket();
+    };
+
+    if (document.readyState === 'complete') {
+      isPageLoadedRef.current = true;
+      connectWebSocket();
+    } else {
+      window.addEventListener('load', handleLoad);
+    }
+
+    return () => {
+      window.removeEventListener('load', handleLoad);
+    };
+  }, [connectWebSocket]);
 
   const reconnect = useCallback(() => {
     connectionAttemptsRef.current = 0;


### PR DESCRIPTION
## Summary
- call `connectWebSocket` when the page `load` event fires
- ignore backend build directory during lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687512b32bd08325a10b87d2af076978