### PR TITLE
Add newline validation to server commands

### DIFF
--- a/server/validate.test.ts
+++ b/server/validate.test.ts
@@ -23,6 +23,8 @@ describe('isValidCmd', () => {
     expect(isValidCmd('echo hello && rm -rf /', allowed)).toBe(false);
     expect(isValidCmd('ls; rm -rf /', allowed)).toBe(false);
     expect(isValidCmd('cat foo | grep bar', allowed)).toBe(false);
+    expect(isValidCmd('echo hi\nrm -rf /', allowed)).toBe(false);
+    expect(isValidCmd('echo hi\r', allowed)).toBe(false);
   });
 
   it('returns false for non-string or empty input', () => {

--- a/server/validate.ts
+++ b/server/validate.ts
@@ -1,6 +1,6 @@
 export function isValidCmd(cmd: string, allowedCmds: string[]): boolean {
   if (typeof cmd !== 'string' || !cmd.trim()) return false;
-  if (/[;&|<>`$]/.test(cmd)) return false;
+  if (/[\n\r;&|<>`$]/.test(cmd)) return false;
   const cleaned = cmd.trim().replace(/^"(.*)"$/, '$1');
   const base = cleaned.split(/\s+/)[0];
   return Array.isArray(allowedCmds) && allowedCmds.includes(base);


### PR DESCRIPTION
## Summary
- disallow newline characters in command validation regex
- test newline cases in validation tests

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68753aaab5088325a0a3351dfde2a646