### PR TITLE
Handle timer cleanup on unmount

### DIFF
--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -117,4 +117,13 @@ export function usePadActions() {
     const unlisten = listen(handler);
     return () => unlisten();
   }, [listen, padActions, handleMacro]);
+
+  useEffect(() => {
+    return () => {
+      Object.values(confirmRef.current).forEach((entry) => {
+        clearTimeout(entry.t);
+      });
+      confirmRef.current = {} as Record<string, { t: ReturnType<typeof setTimeout>; prev: number }>;
+    };
+  }, []);
 }


### PR DESCRIPTION
## Summary
- add cleanup `useEffect` for confirmation timers in `usePadActions`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68753abcf0f88325b13cefa00c53fd49