### PR TITLE
Update test script to build server

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:server": "tsc -p server/tsconfig.json",
     "server": "npm run build:server && node server/dist/index.js",
     "setup": "npm install",
-    "test": "vitest run"
+    "test": "npm run build:server && vitest run"
   },
   "dependencies": {
     "@tonejs/midi": "^2.0.28",

--- a/readme.md
+++ b/readme.md
@@ -115,3 +115,4 @@ testing device specific commands.
 - `npm run lint` – run ESLint
 - `npm run format` – run Prettier
 - `npm run server` – start only the MIDI backend
+- `npm test` – compile the server then run all tests with Vitest


### PR DESCRIPTION
## Summary
- update the `npm test` script to compile the backend first
- note the new test command in README

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68753ad0f93c83259ce30e91561547db