### PR TITLE
Update command validation regex

### DIFF
--- a/server/validate.test.ts
+++ b/server/validate.test.ts
@@ -10,9 +10,14 @@ describe('isValidCmd', () => {
   });
 
   it('handles quoted commands', () => {
-    expect(isValidCmd('"echo hello"', allowed)).toBe(true);
-    expect(isValidCmd('"ls -la"', allowed)).toBe(true);
-    expect(isValidCmd('"rm -rf /"', allowed)).toBe(false);
+    expect(isValidCmd('"echo" hello', allowed)).toBe(true);
+    expect(isValidCmd('"ls" -la', allowed)).toBe(true);
+    expect(isValidCmd('"rm" -rf /', allowed)).toBe(false);
+  });
+
+  it('handles quoted path with arguments', () => {
+    const allowedPath = ['/path/my app'];
+    expect(isValidCmd('"/path/my app" --option', allowedPath)).toBe(true);
   });
 
   it('blocks unlisted commands', () => {

--- a/server/validate.ts
+++ b/server/validate.ts
@@ -1,7 +1,7 @@
 export function isValidCmd(cmd: string, allowedCmds: string[]): boolean {
   if (typeof cmd !== 'string' || !cmd.trim()) return false;
   if (/[\n\r;&|<>`$]/.test(cmd)) return false;
-  const cleaned = cmd.trim().replace(/^"(.*)"$/, '$1');
-  const base = cleaned.split(/\s+/)[0];
+  const match = cmd.trim().match(/^"([^"]+)"|([^\s]+)/);
+  const base = match ? match[1] || match[2] : '';
   return Array.isArray(allowedCmds) && allowedCmds.includes(base);
 }


### PR DESCRIPTION
## Summary
- parse base command with regex that supports quoted paths
- adjust validation tests for quoted commands
- test quoted path with arguments

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877d6bed9548325b4ce5a6ba0a8dbfc