### PR TITLE
Remove unused currentDevices variable

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -38,10 +38,6 @@ function checkKey(req: Request, res: Response, next: NextFunction) {
 
 app.use(checkKey);
 
-// Updated dynamically in listDevices but never read elsewhere
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-let currentDevices = { inputs: [], outputs: [] };
-
 async function startServer() {
   try {
     await WebMidi.enable({ sysex: true });
@@ -60,7 +56,6 @@ async function startServer() {
         manufacturer: output.manufacturer,
         state: output.state,
       }));
-      currentDevices = { inputs, outputs };
       return { inputs, outputs };
     }
 


### PR DESCRIPTION
## Summary
- delete unused `currentDevices` object
- adjust device listing to simply return the current inputs and outputs

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877da3cf610832585cd998b11c4382d