### PR TITLE
Fix imported macro IDs

### DIFF
--- a/src/MacroImportModal.tsx
+++ b/src/MacroImportModal.tsx
@@ -30,7 +30,17 @@ export default function MacroImportModal({ onClose }: Props) {
 
   const confirmImport = () => {
     if (!data) return;
-    useStore.setState((s) => ({ ...s, macros: data }));
+    const base = Date.now();
+    const idMap = new Map<string, string>();
+    data.forEach((m, idx) => {
+      idMap.set(m.id, (base + idx).toString());
+    });
+    const imported = data.map((m) => {
+      const newId = idMap.get(m.id) as string;
+      const next = m.nextId ? (idMap.get(m.nextId) ?? m.nextId) : undefined;
+      return { ...m, id: newId, ...(next ? { nextId: next } : {}) };
+    });
+    useStore.setState((s) => ({ ...s, macros: imported }));
     addToast('Macros imported', 'success');
     onClose();
   };


### PR DESCRIPTION
## Summary
- ensure new macros get new IDs when imported

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: isValidCmd tests in server/validate.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddc1e734832589e78d8a5c22b6b5