### PR TITLE
Fix negative interval input

### DIFF
--- a/src/MacroBuilder.tsx
+++ b/src/MacroBuilder.tsx
@@ -105,10 +105,11 @@ export default function MacroBuilder() {
             />
             <input
               type="number"
+              min="0"
               className="form-control retro-input me-2 mb-1"
               style={{ width: '80px' }}
               value={interval}
-              onChange={(e) => setInterval(Number(e.target.value))}
+              onChange={(e) => setInterval(Math.max(0, Number(e.target.value)))}
             />
           </>
         ) : (

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -241,10 +241,13 @@ export default function MacroList() {
                       />
                       <input
                         type="number"
+                        min="0"
                         className="form-control retro-input me-2 mb-1"
                         style={{ width: '80px' }}
                         value={interval}
-                        onChange={(e) => setInterval(Number(e.target.value))}
+                        onChange={(e) =>
+                          setInterval(Math.max(0, Number(e.target.value)))
+                        }
                       />
                     </>
                   ) : (


### PR DESCRIPTION
## Summary
- prevent negative interval values in macro inputs

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: isValidCmd tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddc546d48325a6cacfd224cb31d1