### PR TITLE
Improve WebSocket auth logic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,12 +37,21 @@ compatibility:
 - `GET /midi/devices` – lists available MIDI inputs and outputs
 - `POST /midi/send` – sends a raw MIDI message to a specified output
 
-A WebSocket on the same port handles the communication used by the frontend.
-When a client connects it sends the current device list and it pushes `devices`
-events whenever ports change. Incoming MIDI messages are forwarded as `midi`
-events so the UI can react in real time. Device listings, outgoing MIDI messages
-and automation commands are all transmitted over this socket as implemented in
-`useMidiConnection.ts` and `useKeyMacroPlayer.ts`.
+  A WebSocket on the same port handles the communication used by the frontend.
+  When a client connects it sends the current device list and it pushes `devices`
+  events whenever ports change. Incoming MIDI messages are forwarded as `midi`
+  events so the UI can react in real time. Device listings, outgoing MIDI messages
+  and automation commands are all transmitted over this socket as implemented in
+  `useMidiConnection.ts` and `useKeyMacroPlayer.ts`.
+
+### API key
+
+Every request to the server, including WebSocket connections, must include the
+server's API key. When the server starts it prints this key to the console. You
+can also set it explicitly via the `API_KEY` environment variable. Configure the
+frontend in the **Settings** panel so the `API key` field matches the value
+logged by the server. A mismatched key will result in the connection being
+rejected with a `401` response.
 
 ### Shell command security
 

--- a/server/validate.ts
+++ b/server/validate.ts
@@ -1,7 +1,8 @@
 export function isValidCmd(cmd: string, allowedCmds: string[]): boolean {
   if (typeof cmd !== 'string' || !cmd.trim()) return false;
-  if (/[;&|<>`$]/.test(cmd)) return false;
-  const cleaned = cmd.trim().replace(/^"(.*)"$/, '$1');
-  const base = cleaned.split(/\s+/)[0];
+  if (/[;&|<>`$\r\n]/.test(cmd)) return false;
+  const trimmed = cmd.trim();
+  const quotedMatch = trimmed.match(/^"([^"\n\r]+)"(?:\s|$)/);
+  const base = quotedMatch ? quotedMatch[1] : trimmed.split(/\s+/)[0];
   return Array.isArray(allowedCmds) && allowedCmds.includes(base);
 }


### PR DESCRIPTION
## Summary
- add verifyClient callback to reject invalid WebSocket connections with 401
- drop runtime key check in connection handler
- document API key usage in README
- harden isValidCmd quoting logic

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f754f972c8325b72e907a70fe7f24