### PR TITLE
Fix settings modal overflow

### DIFF
--- a/src/SettingsModal.css
+++ b/src/SettingsModal.css
@@ -21,3 +21,8 @@
   display: block;
   margin-bottom: 0.5rem;
 }
+
+.settings-scroll {
+  max-height: 70vh;
+  overflow-y: auto;
+}

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -188,7 +188,7 @@ export default function SettingsModal({ onClose }: Props) {
           <div className="modal-header">
             <h5 className="modal-title">◄ SYSTEM CONFIGURATION ►</h5>
           </div>
-          <div className="modal-body">
+          <div className="modal-body settings-scroll">
             <div className="mb-3">
               <label className="form-label text-info">HOST ADDRESS:</label>
               <input


### PR DESCRIPTION
## Summary
- enable scrolling in settings modal
- cap modal body height for better layout

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f9d51fb7c8325b98a21ba79ad7973