### PR TITLE
Allow unlimited WebSocket reconnect attempts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,10 @@ compatibility:
   and automation commands are all transmitted over this socket as implemented in
   `useMidiConnection.ts` and `useKeyMacroPlayer.ts`.
 
+  The frontend's **Settings** panel controls reconnection behavior. Setting
+  _Max reconnect attempts_ to `0` or a negative value removes the limit and the
+  client will continue retrying indefinitely.
+
 ### API key
 
 Every request to the server, including WebSocket connections, must include the

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -446,10 +446,12 @@ export default function SettingsModal({ onClose }: Props) {
                     className="form-control retro-input"
                     value={mra}
                     onChange={(e) => setMra(Number(e.target.value))}
-                    min="1"
+                    min="0"
                     max="99"
                   />
-                  <small className="text-warning">Default: 10</small>
+                  <small className="text-warning">
+                    Default: 10, 0 = unlimited
+                  </small>
                 </div>
               </>
             )}

--- a/src/__tests__/useWebSocket.test.ts
+++ b/src/__tests__/useWebSocket.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWebSocket } from '../useWebSocket';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  public readyState = MockWebSocket.CONNECTING;
+  public onopen: (() => void) | null = null;
+  public onclose: (() => void) | null = null;
+  public onerror: ((ev?: unknown) => void) | null = null;
+  public onmessage: ((ev: { data: string }) => void) | null = null;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(): void {}
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({});
+  }
+
+  // helper for tests
+  triggerClose() {
+    this.close();
+  }
+}
+
+const originalWebSocket = global.WebSocket;
+
+describe('useWebSocket unlimited reconnects', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances.length = 0;
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    global.WebSocket = originalWebSocket;
+  });
+
+  it('reconnects indefinitely when maxReconnectAttempts is 0', () => {
+    const attempts = 5;
+
+    renderHook(() =>
+      useWebSocket({
+        url: 'ws://localhost',
+        autoReconnect: true,
+        reconnectInterval: 100,
+        maxReconnectAttempts: 0,
+      }),
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event('load'));
+    });
+
+    for (let i = 0; i < attempts; i++) {
+      const ws = MockWebSocket.instances[i];
+      act(() => {
+        ws.triggerClose();
+      });
+      vi.advanceTimersByTime(1000);
+    }
+
+    expect(MockWebSocket.instances.length).toBeGreaterThan(attempts);
+  });
+});

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -51,7 +51,7 @@ describe('useStore actions', () => {
 
   it('setMaxReconnectAttempts enforces bounds', () => {
     useStore.getState().setMaxReconnectAttempts(0);
-    expect(useStore.getState().settings.maxReconnectAttempts).toBe(1);
+    expect(useStore.getState().settings.maxReconnectAttempts).toBe(0);
 
     useStore.getState().setMaxReconnectAttempts(150);
     expect(useStore.getState().settings.maxReconnectAttempts).toBe(99);

--- a/src/store.ts
+++ b/src/store.ts
@@ -255,7 +255,7 @@ export const useStore = create<StoreState>()(
         set((state) => ({
           settings: {
             ...state.settings,
-            maxReconnectAttempts: Math.min(99, Math.max(1, max)),
+            maxReconnectAttempts: Math.min(99, Math.max(0, max)),
           },
         })),
       setLogLimit: (limit) =>

--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -86,7 +86,8 @@ export function useWebSocket({
         setStatus('closed');
         if (
           autoReconnect &&
-          connectionAttemptsRef.current <= maxReconnectAttempts &&
+          (maxReconnectAttempts <= 0 ||
+            connectionAttemptsRef.current <= maxReconnectAttempts) &&
           !reconnectTimeoutRef.current
         ) {
           const delay = Math.min(


### PR DESCRIPTION
## Summary
- Allow `maxReconnectAttempts <= 0` to trigger unlimited WebSocket reconnections
- Document and expose unlimited setting in the UI
- Test unlimited reconnect behavior and store clamping

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5434d7cc8325a94736b26956e0cf