### PR TITLE
feat(server): add optional MIDI logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,12 @@ Only `ffmpeg` and `ls` will be accepted by `/run/shell*` routes. Review your
 allowed commands carefully as running arbitrary processes can compromise your
 system.
 
+### MIDI logging
+
+By default the server keeps MIDI logging quiet. Set the `LOG_MIDI` environment
+variable to `true` to print incoming and outgoing MIDI messages along with
+device events to the console.
+
 ---
 
 ## Development workflow


### PR DESCRIPTION
## Summary
- add `LOG_MIDI` env flag to toggle MIDI logging
- document flag and usage in README

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8786cd548325be6fc5a7adfa377f