### PR TITLE
Encode API key in WebSocket URL

### DIFF
--- a/src/useMidiConnection.ts
+++ b/src/useMidiConnection.ts
@@ -18,7 +18,7 @@ export function useMidiConnection() {
   const pingEnabled = useStore((s) => s.settings.pingEnabled);
   const reconnectOnLost = useStore((s) => s.settings.reconnectOnLost);
 
-  const url = `ws://${host}:${port}?key=${apiKey}`;
+  const url = `ws://${host}:${port}?key=${encodeURIComponent(apiKey)}`;
 
   const {
     status,


### PR DESCRIPTION
## Summary
- Use `encodeURIComponent` when building the WebSocket URL so API keys with special characters are properly escaped.

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bac1f5adc8325b21abff07f2842da