### PR TITLE
fix: stop reconnecting after max attempts

### DIFF
--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -87,7 +87,7 @@ export function useWebSocket({
         if (
           autoReconnect &&
           (maxReconnectAttempts <= 0 ||
-            connectionAttemptsRef.current <= maxReconnectAttempts) &&
+            connectionAttemptsRef.current < maxReconnectAttempts) &&
           !reconnectTimeoutRef.current
         ) {
           const delay = Math.min(


### PR DESCRIPTION
## Summary
- stop reconnecting WebSocket after reaching maxReconnectAttempts

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bac1a44bc8325bd17091ee6a66a7a