### PR TITLE
Propagate server startup errors

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -352,11 +352,15 @@ async function startServer() {
     return server;
   } catch (err) {
     console.error('Failed to enable WebMidi:', err);
+    throw err;
   }
 }
 
 if (require.main === module) {
-  startServer();
+  startServer().catch((err) => {
+    console.error('Server failed to start:', err);
+    process.exit(1);
+  });
 }
 
 export { app, startServer };


### PR DESCRIPTION
## Summary
- Re-throw WebMidi initialization errors in `startServer`
- Handle startup failures when running the server directly

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689baee3b41883258254b1235598eefb