### PR TITLE
Store and clear toast timeout IDs

### DIFF
--- a/src/toastStore.ts
+++ b/src/toastStore.ts
@@ -6,6 +6,7 @@ export interface Toast {
   id: string;
   message: string;
   type: ToastType;
+  timeoutId: ReturnType<typeof setTimeout>;
 }
 
 interface ToastState {
@@ -18,16 +19,23 @@ export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
   addToast: (message, type) => {
     const id = crypto.randomUUID();
-    set((state) => {
-      if (state.toasts.length >= 5) {
-        return { toasts: state.toasts };
-      }
-      return { toasts: [...state.toasts, { id, message, type }] };
-    });
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
     }, 4000);
+    set((state) => {
+      if (state.toasts.length >= 5) {
+        clearTimeout(timeoutId);
+        return { toasts: state.toasts };
+      }
+      return { toasts: [...state.toasts, { id, message, type, timeoutId }] };
+    });
   },
   removeToast: (id) =>
-    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+    set((state) => {
+      const toast = state.toasts.find((t) => t.id === id);
+      if (toast) {
+        clearTimeout(toast.timeoutId);
+      }
+      return { toasts: state.toasts.filter((t) => t.id !== id) };
+    }),
 }));


### PR DESCRIPTION
## Summary
- store timeout ID with each toast so pending timers can be tracked
- clear a toast's timeout before removal to avoid orphaned timers

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689baedd25a88325a428895a72b58012