### PR TITLE
Store reconnect timeout ref

### DIFF
--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -159,8 +159,14 @@ export function useWebSocket({
         clearTimeout(reconnectTimeoutRef.current);
         reconnectTimeoutRef.current = null;
       }
-      setTimeout(connectWebSocket, 100);
+      reconnectTimeoutRef.current = setTimeout(connectWebSocket, 100);
     }
+    return () => {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+    };
   }, [url, connectWebSocket]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- store reconnect timeout ID in a ref and clean it up when URL changes

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689baeda3244832581f65345f2e36091