### PR TITLE
feat: make API key optional

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,11 +50,11 @@ compatibility:
 
 ### API key
 
-Every request to the server, including WebSocket connections, must include the
-server's API key. When the server starts it prints this key to the console. You
-can also set it explicitly via the `API_KEY` environment variable. Configure the
-frontend in the **Settings** panel so the `API key` field matches the value
-logged by the server. A mismatched key will result in the connection being
+By default the server accepts requests without authentication. Set the
+`API_KEY` environment variable to require a matching key on all requests,
+including WebSocket connections. When `LOG_API_KEY=true` the server prints the
+active key to the console. Configure the frontend in the **Settings** panel so
+the `API key` field matches this value, otherwise the connection will be
 rejected with a `401` response.
 
 ### Shell command security

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,13 +7,10 @@ import keySender from 'node-key-sender';
 import notifier from 'toasted-notifier';
 import cors from 'cors';
 import { exec, spawn } from 'child_process';
-import crypto from 'crypto';
 
 import { isValidCmd } from './validate.js';
 
-const envKey = process.env.API_KEY;
-const API_KEY =
-  envKey === undefined ? crypto.randomBytes(16).toString('hex') : envKey;
+const API_KEY = process.env.API_KEY || undefined;
 if (process.env.LOG_API_KEY === 'true') {
   console.log('API key:', API_KEY);
 } else if (API_KEY) {
@@ -34,8 +31,12 @@ app.use(express.json());
 app.use(cors());
 
 function checkKey(req: Request, res: Response, next: NextFunction) {
+  if (!API_KEY) {
+    next();
+    return;
+  }
   const key = req.headers['x-api-key'];
-  if (API_KEY && key !== API_KEY) {
+  if (key !== API_KEY) {
     res.status(401).json({ error: 'unauthorized' });
     return;
   }


### PR DESCRIPTION
## Summary
- default `API_KEY` to `undefined` when env variable missing
- skip auth middleware when no API key is set
- document default unauthenticated behavior in README

## Testing
- `npx prettier server/index.ts readme.md --write`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Cannot read properties of undefined (reading 'triggerClose'))*

------
https://chatgpt.com/codex/tasks/task_e_689bbd3ef40c8325b960e7d181c34111