### PR TITLE
Refactor shell command execution and validation

### DIFF
--- a/server/validate.test.ts
+++ b/server/validate.test.ts
@@ -1,35 +1,46 @@
 import { describe, it, expect } from 'vitest';
+import path from 'node:path';
 import { isValidCmd } from './dist/validate.js';
 
-const allowed = ['echo', 'ls', 'cat'];
+const echoPath = '/usr/bin/echo';
+const lsPath = '/usr/bin/ls';
+const allowed = [echoPath, lsPath, '/usr/bin/cat'];
 
 describe('isValidCmd', () => {
   it('allows whitelisted commands', () => {
-    expect(isValidCmd('echo hello', allowed)).toBe(true);
-    expect(isValidCmd('ls -la', allowed)).toBe(true);
+    expect(isValidCmd(`${echoPath} hello`, allowed)).toBe(true);
+    expect(isValidCmd(`${lsPath} -la`, allowed)).toBe(true);
   });
 
   it('handles quoted commands', () => {
-    expect(isValidCmd('"echo" hello', allowed)).toBe(true);
-    expect(isValidCmd('"ls" -la', allowed)).toBe(true);
-    expect(isValidCmd('"rm" -rf /', allowed)).toBe(false);
+    expect(isValidCmd(`"${echoPath}" hello`, allowed)).toBe(true);
+    expect(isValidCmd(`'${echoPath}' hello`, allowed)).toBe(true);
+    expect(isValidCmd(`"${lsPath}" -la`, allowed)).toBe(true);
+    expect(isValidCmd('"/usr/bin/rm" -rf /', allowed)).toBe(false);
   });
 
-  it('handles quoted path with arguments', () => {
+  it('handles relative paths safely', () => {
+    const rel = path.relative(process.cwd(), echoPath);
+    expect(isValidCmd(`${rel} hi`, allowed)).toBe(true);
+    expect(isValidCmd(`'${rel}' hi`, allowed)).toBe(true);
+  });
+
+  it('handles quoted path with spaces', () => {
     const allowedPath = ['/path/my app'];
     expect(isValidCmd('"/path/my app" --option', allowedPath)).toBe(true);
+    expect(isValidCmd("'/path/my app' --option", allowedPath)).toBe(true);
   });
 
   it('blocks unlisted commands', () => {
-    expect(isValidCmd('rm -rf /', allowed)).toBe(false);
+    expect(isValidCmd('/bin/ls', ['/usr/bin/echo'])).toBe(false);
   });
 
   it('blocks commands with dangerous characters', () => {
-    expect(isValidCmd('echo hello && rm -rf /', allowed)).toBe(false);
-    expect(isValidCmd('ls; rm -rf /', allowed)).toBe(false);
-    expect(isValidCmd('cat foo | grep bar', allowed)).toBe(false);
-    expect(isValidCmd('echo hi\nrm -rf /', allowed)).toBe(false);
-    expect(isValidCmd('echo hi\r', allowed)).toBe(false);
+    expect(isValidCmd(`${echoPath} hello && rm -rf /`, allowed)).toBe(false);
+    expect(isValidCmd(`${lsPath}; rm -rf /`, allowed)).toBe(false);
+    expect(isValidCmd('/usr/bin/cat foo | grep bar', allowed)).toBe(false);
+    expect(isValidCmd(`${echoPath} hi\nrm -rf /`, allowed)).toBe(false);
+    expect(isValidCmd(`${echoPath} hi\r`, allowed)).toBe(false);
   });
 
   it('returns false for non-string or empty input', () => {

--- a/server/validate.ts
+++ b/server/validate.ts
@@ -1,8 +1,23 @@
+import path from 'node:path';
+
+export function parseCmd(cmd: string): { file: string; args: string[] } | null {
+  const parts =
+    cmd
+      .match(/(?:[^\s'"]+|'[^']*'|"[^"]*")+/g)
+      ?.map((p) => p.replace(/^['"]|['"]$/g, '')) ?? [];
+  if (parts.length === 0) return null;
+  const [file, ...args] = parts;
+  return { file, args };
+}
+
 export function isValidCmd(cmd: string, allowedCmds: string[]): boolean {
   if (typeof cmd !== 'string' || !cmd.trim()) return false;
   if (/[;&|<>`$\r\n]/.test(cmd)) return false;
-  const trimmed = cmd.trim();
-  const quotedMatch = trimmed.match(/^"([^"\n\r]+)"(?:\s|$)/);
-  const base = quotedMatch ? quotedMatch[1] : trimmed.split(/\s+/)[0];
-  return Array.isArray(allowedCmds) && allowedCmds.includes(base);
+  const parsed = parseCmd(cmd.trim());
+  if (!parsed) return false;
+  const resolved = path.resolve(parsed.file);
+  return (
+    Array.isArray(allowedCmds) &&
+    allowedCmds.some((allowed) => path.resolve(allowed) === resolved)
+  );
 }


### PR DESCRIPTION
## Summary
- replace unsafe `exec` calls with `spawn` and explicit args
- validate command paths with `parseCmd` supporting quotes and relative paths
- add tests for command validation and shell routes

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: useMidi reconnect logic; useWebSocket unlimited reconnects)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd40d52c83259e9368281a6440a9