### PR TITLE
Handle missing MIDI target port

### DIFF
--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -37,7 +37,8 @@ export function useMidi() {
 
   const send = useCallback(
     (bytes: number[] | Uint8Array) => {
-      const targetPort = selectedOutput || launchpadRef.current || '';
+      const targetPort = selectedOutput || launchpadRef.current;
+      if (!targetPort) return false;
       const bytesArray = Array.from(bytes);
       return sendRaw({ type: 'send', port: targetPort, bytes: bytesArray });
     },
@@ -96,6 +97,10 @@ export function useMidi() {
   }, [listenRaw]);
 
   useEffect(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     if (launchpadRef.current !== null && status === 'connected') {
       timeoutRef.current = setTimeout(() => {
         sendRef.current([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x01, 0xf7]);


### PR DESCRIPTION
## Summary
- Avoid sending MIDI messages when no target port is available
- Manage Launchpad SysEx timeout by storing and clearing the timeout ID

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bc352fc508325bb8c8d17700686cc