### PR TITLE
feat: add toast id fallback

### DIFF
--- a/src/toastStore.ts
+++ b/src/toastStore.ts
@@ -18,7 +18,10 @@ interface ToastState {
 export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
   addToast: (message, type) => {
-    const id = crypto.randomUUID();
+    const id =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`;
     const timeoutId = setTimeout(() => {
       set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
     }, 4000);


### PR DESCRIPTION
## Summary
- ensure toast IDs use `crypto.randomUUID` when available
- fall back to timestamp and random number when `crypto.randomUUID` is missing

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd064880c83258a65542646accb86