### PR TITLE
Guard debug logging in macro hooks

### DIFF
--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -23,7 +23,9 @@ export function useKeyMacroPlayer() {
       visited.add(macroId);
       const macro = macros.find((m) => m.id === macroId);
       if (!macro) return;
-      console.log('Playing macro', macro);
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('Playing macro', macro);
+      }
       addToast(`Playing: ${macro.name}`, 'success');
       try {
         const { type, payload } = MACRO_MESSAGES[macro.type || 'keys'];

--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -50,7 +50,14 @@ export function usePadActions() {
       confirm?: boolean,
       toastConfirm?: boolean,
     ) => {
-      console.log('Pad macro trigger', { macroId, id, confirm, toastConfirm });
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('Pad macro trigger', {
+          macroId,
+          id,
+          confirm,
+          toastConfirm,
+        });
+      }
       if (!confirm) {
         playMacro(macroId);
         return;
@@ -123,7 +130,10 @@ export function usePadActions() {
       Object.values(confirmRef.current).forEach((entry) => {
         clearTimeout(entry.t);
       });
-      confirmRef.current = {} as Record<string, { t: ReturnType<typeof setTimeout>; prev: number }>;
+      confirmRef.current = {} as Record<
+        string,
+        { t: ReturnType<typeof setTimeout>; prev: number }
+      >;
     };
   }, []);
 }


### PR DESCRIPTION
## Summary
- wrap pad macro logging with a NODE_ENV check
- conditionally log macro playback in key macro player

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd05897b08325be6f322ea7f533d6