### PR TITLE
fix: guard window and document in useWebSocket

### DIFF
--- a/src/useWebSocket.ts
+++ b/src/useWebSocket.ts
@@ -140,16 +140,18 @@ export function useWebSocket({
       connectWebSocket();
     };
 
-    if (document.readyState === 'complete') {
-      isPageLoadedRef.current = true;
-      connectWebSocket();
-    } else {
-      window.addEventListener('load', handleLoad);
-    }
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      if (document.readyState === 'complete') {
+        isPageLoadedRef.current = true;
+        connectWebSocket();
+      } else {
+        window.addEventListener('load', handleLoad);
+      }
 
-    return () => {
-      window.removeEventListener('load', handleLoad);
-    };
+      return () => {
+        window.removeEventListener('load', handleLoad);
+      };
+    }
   }, [connectWebSocket]);
 
   const reconnect = useCallback(() => {


### PR DESCRIPTION
## Summary
- guard window and document usage in useWebSocket hook

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bdfd5e6888325b60f6c071e2ed7b9