### PR TITLE
Clear timeout on unmount

### DIFF
--- a/src/useMidi.ts
+++ b/src/useMidi.ts
@@ -97,21 +97,16 @@ export function useMidi() {
   }, [listenRaw]);
 
   useEffect(() => {
-    if (timeoutRef.current !== null) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
     if (launchpadRef.current !== null && status === 'connected') {
-      timeoutRef.current = setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         sendRef.current([0xf0, 0x00, 0x20, 0x29, 0x02, 0x0c, 0x0e, 0x01, 0xf7]);
       }, 1000);
-    }
-    return () => {
-      if (timeoutRef.current !== null) {
-        clearTimeout(timeoutRef.current);
+      timeoutRef.current = timeoutId;
+      return () => {
+        clearTimeout(timeoutId);
         timeoutRef.current = null;
-      }
-    };
+      };
+    }
   }, [status]);
 
   return {

--- a/src/useMidiTimeout.test.ts
+++ b/src/useMidiTimeout.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+interface StoreState {
+  devices: { outputId: string | null };
+}
+
+let storeState: StoreState;
+
+vi.mock('./store', () => ({
+  useStore: <T>(selector: (s: StoreState) => T): T => selector(storeState),
+}));
+
+const sendMock = vi.fn();
+const listenMock = vi.fn(() => () => {});
+const reconnectMock = vi.fn();
+
+vi.mock('./useMidiConnection', () => ({
+  useMidiConnection: () => ({
+    status: 'connected',
+    pingDelay: 0,
+    send: sendMock,
+    listen: listenMock,
+    reconnect: reconnectMock,
+  }),
+}));
+
+import { useMidi } from './useMidi';
+
+describe('useMidi timeout cleanup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sendMock.mockReset();
+    storeState = { devices: { outputId: null } };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not send message if unmounted before timeout', () => {
+    const { unmount } = renderHook(() => useMidi());
+    unmount();
+    vi.advanceTimersByTime(1000);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- store timeout ID for launchpad detection and clean it up on unmount
- test that no MIDI message is sent after unmounting before timeout

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bdfdb3f5083259270ee8eb0002fab