### PR TITLE
refactor: type MIDI messages

### DIFF
--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,16 @@
+export interface MidiMessage {
+  type: 'send';
+  port: string;
+  bytes: number[];
+}
+
+export interface MidiEvent {
+  type: 'midi';
+  direction: 'in' | 'out';
+  message: number[];
+  timestamp: number;
+  port: string;
+  source?: string;
+  target?: string;
+  pressure?: number;
+}


### PR DESCRIPTION
## Summary
- define `MidiEvent` and `MidiMessage` interfaces for WebSocket MIDI traffic
- refactor server to use typed MIDI structures and drop eslint disables

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20b230b2c8325a61010c2d351764c