### PR TITLE
refactor: modularize websocket handlers

### DIFF
--- a/server/handlers/exec.ts
+++ b/server/handlers/exec.ts
@@ -1,0 +1,48 @@
+import { exec, spawn } from 'child_process';
+import { isValidCmd } from '../validate.js';
+import type { MessageHandler } from './types.js';
+
+const handleRunApp: MessageHandler = (_ws, data, ctx) => {
+  const { app: appPath } = data;
+  if (!appPath) return;
+  if (!isValidCmd(appPath, ctx.allowedCmds)) return;
+  exec(`"${appPath}"`, (err) => {
+    if (err) console.error('App exec error:', err);
+  });
+};
+
+const handleRunShell: MessageHandler = (_ws, data, ctx) => {
+  const { cmd } = data;
+  if (!cmd) return;
+  if (!isValidCmd(cmd, ctx.allowedCmds)) return;
+  exec(cmd, (err) => {
+    if (err) console.error('Shell exec error:', err);
+  });
+};
+
+const handleRunShellWin: MessageHandler = (_ws, data, ctx) => {
+  const { cmd } = data;
+  if (!cmd) return;
+  if (!isValidCmd(cmd, ctx.allowedCmds)) return;
+  try {
+    const child = spawn(cmd, {
+      shell: true,
+      detached: true,
+      windowsHide: false,
+    });
+    child.unref();
+  } catch (err) {
+    console.error('ShellWin spawn error:', err);
+  }
+};
+
+const handleRunShellBg: MessageHandler = (_ws, data, ctx) => {
+  const { cmd } = data;
+  if (!cmd) return;
+  if (!isValidCmd(cmd, ctx.allowedCmds)) return;
+  exec(cmd, { windowsHide: true }, (err) => {
+    if (err) console.error('ShellBg exec error:', err);
+  });
+};
+
+export { handleRunApp, handleRunShell, handleRunShellWin, handleRunShellBg };

--- a/server/handlers/index.ts
+++ b/server/handlers/index.ts
@@ -1,0 +1,26 @@
+import { handleGetDevices, handleSend } from './midi.js';
+import {
+  handleRunApp,
+  handleRunShell,
+  handleRunShellWin,
+  handleRunShellBg,
+} from './exec.js';
+import { handleKeysType } from './keys.js';
+import { handleNotify } from './notify.js';
+import { handlePing } from './ping.js';
+import type { MessageHandler } from './types.js';
+
+const handlers: Record<string, MessageHandler> = {
+  getDevices: handleGetDevices,
+  send: handleSend,
+  runApp: handleRunApp,
+  runShell: handleRunShell,
+  runShellWin: handleRunShellWin,
+  runShellBg: handleRunShellBg,
+  keysType: handleKeysType,
+  notify: handleNotify,
+  ping: handlePing,
+};
+
+export { handlers };
+export type { MessageHandler, HandlerContext } from './types.js';

--- a/server/handlers/keys.ts
+++ b/server/handlers/keys.ts
@@ -1,0 +1,19 @@
+import keySender from 'node-key-sender';
+import type { MessageHandler } from './types.js';
+
+const handleKeysType: MessageHandler = async (_ws, data, _ctx) => {
+  const { sequence = [], interval = 50 } = data;
+  void _ctx;
+  try {
+    for (const key of sequence) {
+      await keySender.sendKey(key);
+      if (interval > 0) {
+        await new Promise((r) => setTimeout(r, interval));
+      }
+    }
+  } catch (err) {
+    console.error('Key send error:', err);
+  }
+};
+
+export { handleKeysType };

--- a/server/handlers/midi.ts
+++ b/server/handlers/midi.ts
@@ -1,0 +1,44 @@
+import { WebMidi } from 'webmidi';
+import type { MessageHandler } from './types.js';
+
+const handleGetDevices: MessageHandler = (ws, _data, ctx) => {
+  ctx.sendDevices(ws);
+};
+
+const handleSend: MessageHandler = (_ws, data, ctx) => {
+  const { port = '', bytes } = data;
+  const out = WebMidi.getOutputById(String(port));
+  if (!out) {
+    console.error('Invalid output port:', { port });
+    return;
+  }
+  if (!ctx.isValidByteArray(bytes)) {
+    console.error('Invalid bytes array:', { bytes });
+    return;
+  }
+  try {
+    out.send(bytes);
+    if (ctx.LOG_MIDI)
+      console.log(`Sent MIDI via WebSocket to ${out.name}:`, bytes);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outMsg: any = {
+      type: 'midi',
+      direction: 'out',
+      message: bytes,
+      timestamp: Date.now(),
+      target: out.name,
+      port: port,
+    };
+    if (
+      bytes.length >= 3 &&
+      ((bytes[0] & 0xf0) === 0xa0 || (bytes[0] & 0xf0) === 0xd0)
+    ) {
+      outMsg.pressure = bytes[2];
+    }
+    ctx.broadcastToClients(outMsg);
+  } catch (err) {
+    console.error('WebSocket MIDI send error:', err);
+  }
+};
+
+export { handleGetDevices, handleSend };

--- a/server/handlers/notify.ts
+++ b/server/handlers/notify.ts
@@ -1,0 +1,13 @@
+import notifier from 'toasted-notifier';
+import type { MessageHandler } from './types.js';
+
+const handleNotify: MessageHandler = (_ws, data, _ctx) => {
+  const { title = 'Automidi', message } = data;
+  void _ctx;
+  if (!message) return;
+  notifier.notify({ title, message }, (err) => {
+    if (err) console.error('Notification error:', err);
+  });
+};
+
+export { handleNotify };

--- a/server/handlers/ping.ts
+++ b/server/handlers/ping.ts
@@ -1,0 +1,8 @@
+import type { MessageHandler } from './types.js';
+
+const handlePing: MessageHandler = (ws, data, _ctx) => {
+  void _ctx;
+  ws.send(JSON.stringify({ type: 'pong', ts: data.ts || Date.now() }));
+};
+
+export { handlePing };

--- a/server/handlers/types.ts
+++ b/server/handlers/types.ts
@@ -1,0 +1,16 @@
+import type { WebSocket } from 'ws';
+
+export interface HandlerContext {
+  sendDevices: (ws?: WebSocket) => void;
+  isValidByteArray: (arr: unknown) => arr is number[];
+  broadcastToClients: (message: unknown) => void;
+  allowedCmds: string[];
+  LOG_MIDI: boolean;
+}
+
+export type MessageHandler = (
+  ws: WebSocket,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any,
+  context: HandlerContext,
+) => void;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,6 +11,6 @@
     "noEmitOnError": false,
     "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.server.tsbuildinfo"
   },
-  "include": ["index.ts", "validate.ts"],
+  "include": ["index.ts", "validate.ts", "handlers/**/*.ts"],
   "exclude": ["**/*.test.ts", "__tests__", "dist"]
 }


### PR DESCRIPTION
## Summary
- extract WebSocket message handlers into dedicated `server/handlers` modules
- add dispatcher to route `data.type` messages to handlers
- simplify `wss` connection logic to use centralized dispatch

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a20b1ef38c832584c895165011f52b