### PR TITLE
Add validation and MIDI WebSocket tests

### DIFF
--- a/server/__tests__/isValidCmd.test.ts
+++ b/server/__tests__/isValidCmd.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { isValidCmd } from '../dist/validate.js';
+
+describe('isValidCmd rejects tricky inputs', () => {
+  const allowed = ['echo', 'app'];
+
+  it('rejects quoted paths not in allow list', () => {
+    expect(isValidCmd('"/evil path"', allowed)).toBe(false);
+  });
+
+  it('rejects commands with only spaces', () => {
+    expect(isValidCmd('   ', allowed)).toBe(false);
+  });
+
+  it('rejects unicode lookalike commands', () => {
+    expect(isValidCmd('ｅｃｈｏ hi', allowed)).toBe(false);
+  });
+});

--- a/server/__tests__/websocketMidi.test.ts
+++ b/server/__tests__/websocketMidi.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import WebSocket from 'ws';
+import type { Server } from 'http';
+import type { SendMidiMessage } from '../../shared/messages';
+
+describe('WebSocket MIDI handling', () => {
+  const API_KEY = 'test-key';
+  let server: Server;
+  let stopServer: () => Promise<void>;
+  let send: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.API_KEY = API_KEY;
+    process.env.ALLOWED_CMDS = '';
+    process.env.PORT = '0';
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const wm = require('webmidi');
+    wm.WebMidi.enable = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn();
+    const output = { id: '1', name: 'out', send };
+    Object.defineProperty(wm.WebMidi, 'inputs', {
+      value: [],
+      configurable: true,
+    });
+    Object.defineProperty(wm.WebMidi, 'outputs', {
+      value: [output],
+      configurable: true,
+    });
+    wm.WebMidi.addListener = vi.fn();
+    wm.WebMidi.getOutputById = vi.fn((id: string) =>
+      id === '1' ? output : undefined,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('../dist/index.js');
+    server = await mod.startServer();
+    stopServer = mod.stopServer;
+  });
+
+  afterEach(async () => {
+    await stopServer();
+    vi.clearAllMocks();
+  });
+
+  it('ignores invalid midi messages', async () => {
+    const port = (server.address() as { port: number }).port;
+    const ws = new WebSocket(`ws://localhost:${port}?key=${API_KEY}`);
+    await new Promise((r) => ws.on('open', r));
+
+    const msg: SendMidiMessage = { type: 'send', port: '1', bytes: [256] };
+    ws.send(JSON.stringify(msg));
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(send).not.toHaveBeenCalled();
+    ws.close();
+  });
+});


### PR DESCRIPTION
## Summary
- test isValidCmd against quoted paths, whitespace-only strings, and unicode lookalikes
- ensure WebSocket ignores invalid MIDI send messages

## Testing
- `npm run lint`
- `npm run build`
- `npm run build:server`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25b8ca6d08325a1230dc314beb33e