### PR TITLE
feat: add MIDI payload guards

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,39 @@
+import type { MidiDevice } from '../shared/messages';
+
+export interface DevicesMessage {
+  type: 'devices';
+  inputs?: MidiDevice[];
+  outputs?: MidiDevice[];
+}
+
+export interface MidiPayload {
+  type: 'midi';
+  direction: 'in' | 'out';
+  message: number[];
+  timestamp: number;
+  source?: string;
+  target?: string;
+  port?: string;
+  pressure?: number;
+}
+
+export type MidiServerMessage = DevicesMessage | MidiPayload;
+
+export function isDevicesMessage(msg: unknown): msg is DevicesMessage {
+  if (!msg || typeof msg !== 'object') return false;
+  const m = msg as Partial<DevicesMessage>;
+  if (m.type !== 'devices') return false;
+  if (m.inputs && !Array.isArray(m.inputs)) return false;
+  if (m.outputs && !Array.isArray(m.outputs)) return false;
+  return true;
+}
+
+export function isMidiPayload(msg: unknown): msg is MidiPayload {
+  if (!msg || typeof msg !== 'object') return false;
+  const m = msg as Partial<MidiPayload>;
+  if (m.type !== 'midi') return false;
+  if (m.direction !== 'in' && m.direction !== 'out') return false;
+  if (!Array.isArray(m.message)) return false;
+  if (typeof m.timestamp !== 'number') return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- add DevicesMessage and MidiPayload interfaces with runtime type guards
- validate WebSocket payloads in useMidi via new guards

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25b7b5cc08325a5cc9901fc563eb1