### PR TITLE
feat: support notification titles

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,9 +1,14 @@
 import { useToastStore } from './toastStore';
 import { sendSocketMessage } from './socket';
 
-export function notify(message: string) {
+export interface NotifyOptions {
+  message: string;
+  title?: string;
+}
+
+export function notify({ message, title }: NotifyOptions) {
   const addToast = useToastStore.getState().addToast;
-  const ok = sendSocketMessage({ type: 'notify', message });
+  const ok = sendSocketMessage({ type: 'notify', title, message });
   if (!ok) {
     addToast(message, 'success');
   }

--- a/src/usePadActions.ts
+++ b/src/usePadActions.ts
@@ -72,7 +72,10 @@ export function usePadActions() {
             .getState()
             .addToast('Press pad again to confirm', 'success');
         } else {
-          notify('Press pad again to confirm');
+          notify({
+            message: 'Press pad again to confirm',
+            title: 'Macro Confirmation',
+          });
         }
         const t = setTimeout(() => {
           setPadChannel(id, prev);


### PR DESCRIPTION
## Summary
- extend notify to accept message/title options
- send title and message through WebSocket
- use titled notification when confirming pad macros

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26cacb4048325bae168e7e8d1b56b