### PR TITLE
Handle notify errors

### DIFF
--- a/server/__tests__/notifyRoute.test.ts
+++ b/server/__tests__/notifyRoute.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Server } from 'http';
+
+describe('notify route', () => {
+  const API_KEY = 'test-key';
+  let server: Server;
+  let stopServer: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const tn = require('toasted-notifier');
+    vi.spyOn(tn, 'notify').mockImplementation(
+      (_opts: unknown, cb: (err: Error | null) => void) => {
+        cb(new Error('fail'));
+      },
+    );
+    process.env.API_KEY = API_KEY;
+    process.env.PORT = '0';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const wm = require('webmidi');
+    wm.WebMidi.enable = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(wm.WebMidi, 'inputs', {
+      value: [],
+      configurable: true,
+    });
+    Object.defineProperty(wm.WebMidi, 'outputs', {
+      value: [],
+      configurable: true,
+    });
+    wm.WebMidi.addListener = vi.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('../dist/index.js');
+    server = await mod.startServer();
+    stopServer = mod.stopServer;
+  });
+
+  afterEach(async () => {
+    await stopServer();
+    vi.clearAllMocks();
+  });
+
+  it('returns 500 when notification fails', async () => {
+    const agent = request(server);
+    await agent
+      .post('/notify')
+      .set('x-api-key', API_KEY)
+      .send({ message: 'hi' })
+      .expect(500);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -164,9 +164,13 @@ async function startServer() {
         return;
       }
       notifier.notify({ title, message }, (err) => {
-        if (err) console.error('Notification error:', err);
+        if (err) {
+          console.error('Notification error:', err);
+          res.status(500).json({ error: err.message });
+          return;
+        }
+        res.json({ ok: true });
       });
-      res.json({ ok: true });
     });
 
     app.post('/keys/type', async (req, res) => {


### PR DESCRIPTION
## Summary
- return HTTP 500 when notification delivery fails in `/notify`
- add test mocking toast notifier error path

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26cdbad708325b4b62ae7f51ce55e