### PR TITLE
feat: add macro export button

### DIFF
--- a/src/MacroExportButton.tsx
+++ b/src/MacroExportButton.tsx
@@ -1,0 +1,21 @@
+import { useStore } from './store';
+
+export default function MacroExportButton() {
+  const handleExport = () => {
+    const macros = useStore.getState().macros;
+    const data = JSON.stringify(macros);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'macros.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button className="retro-button btn-sm me-1" onClick={handleExport}>
+      EXPORT
+    </button>
+  );
+}

--- a/src/MacroList.tsx
+++ b/src/MacroList.tsx
@@ -5,6 +5,7 @@ import { useToastStore } from './toastStore';
 import { useState } from 'react';
 import MacroImportModal from './MacroImportModal';
 import MacroInstructions from './MacroInstructions';
+import MacroExportButton from './MacroExportButton';
 
 export default function MacroList() {
   const macros = useStore((s) => s.macros);
@@ -80,18 +81,6 @@ export default function MacroList() {
   };
   const closePreview = () => setPreviewId(null);
 
-  const exportMacros = () => {
-    const data = JSON.stringify(macros);
-    const blob = new Blob([data], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'macros.json';
-    a.click();
-    URL.revokeObjectURL(url);
-    addToast('Macros exported', 'success');
-  };
-
   return (
     <div className="retro-panel">
       <div className="d-flex justify-content-between align-items-center mb-2">
@@ -103,9 +92,7 @@ export default function MacroList() {
           >
             HELP
           </button>
-          <button className="retro-button btn-sm me-1" onClick={exportMacros}>
-            EXPORT
-          </button>
+          <MacroExportButton />
           <button
             className="retro-button btn-sm"
             onClick={() => setShowImport(true)}

--- a/src/__tests__/MacroExportButton.test.tsx
+++ b/src/__tests__/MacroExportButton.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
+import MacroExportButton from '../MacroExportButton';
+import { renderWithStore, resetStores } from './testUtils';
+import { useStore } from '../store';
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => ({}),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+describe('MacroExportButton', () => {
+  const macros = [
+    { id: '1', name: 'One', sequence: ['a'], interval: 10, tags: ['foo'] },
+  ];
+
+  beforeEach(() => {
+    resetStores();
+    useStore.setState((s) => ({ ...s, macros }), true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('downloads macros as JSON', async () => {
+    const user = userEvent.setup();
+    const originalCreate = document.createElement.bind(document);
+    const anchor = originalCreate('a');
+    vi.spyOn(document, 'createElement').mockImplementation(
+      (tag: string, options?: ElementCreationOptions) =>
+        tag === 'a' ? anchor : originalCreate(tag, options),
+    );
+    const click = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    const revokeObjectURL = vi.fn();
+    Object.assign(URL as unknown as Record<string, unknown>, {
+      createObjectURL,
+      revokeObjectURL,
+    });
+    const stringify = vi.spyOn(JSON, 'stringify');
+
+    renderWithStore(<MacroExportButton />);
+
+    await user.click(screen.getByText('EXPORT'));
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(stringify).toHaveBeenCalledWith(macros);
+    const blob = createObjectURL.mock.calls[0][0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(anchor.download).toBe('macros.json');
+    expect(click).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- export macros to a JSON file with new MacroExportButton component
- add export control next to import controls on macro list
- test macro export download behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc41bdeb1c832589cbc9a275b3116a