### PR TITLE
Add health check route for server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,11 +31,12 @@ Start it with:
 npm run server
 ```
 
-It listens on port `3000` and still exposes two REST endpoints for
-compatibility:
+It listens on port `3000` and exposes REST endpoints for compatibility and
+monitoring:
 
 - `GET /midi/devices` – lists available MIDI inputs and outputs
 - `POST /midi/send` – sends a raw MIDI message to a specified output
+- `GET /health` – returns `{ ok: true }` for health checks
 
   A WebSocket on the same port handles the communication used by the frontend.
   When a client connects it sends the current device list and it pushes `devices`

--- a/server/__tests__/healthRoute.test.ts
+++ b/server/__tests__/healthRoute.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import type { Server } from 'http';
+
+describe('health route', () => {
+  let server: Server;
+  let stopServer: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.PORT = '0';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const wm = require('webmidi');
+    wm.WebMidi.enable = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(wm.WebMidi, 'inputs', {
+      value: [],
+      configurable: true,
+    });
+    Object.defineProperty(wm.WebMidi, 'outputs', {
+      value: [],
+      configurable: true,
+    });
+    wm.WebMidi.addListener = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('../dist/index.js');
+    server = await mod.startServer();
+    stopServer = mod.stopServer;
+  });
+
+  afterEach(async () => {
+    await stopServer();
+    vi.clearAllMocks();
+  });
+
+  it('returns ok', async () => {
+    const agent = request(server);
+    await agent.get('/health').expect(200).expect({ ok: true });
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -109,6 +109,10 @@ function checkKey(req: Request, res: Response, next: NextFunction) {
 
 app.use(checkKey);
 
+app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
 function isValidByteArray(arr: unknown): arr is number[] {
   return (
     Array.isArray(arr) &&


### PR DESCRIPTION
## Summary
- add `/health` HTTP endpoint returning `{ ok: true }`
- document health check in server README section
- test health route for 200 response

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc65818008325b1467ac2b5a3e7e1