### PR TITLE
Add MIDI macro support

### DIFF
--- a/src/MacroBuilder.tsx
+++ b/src/MacroBuilder.tsx
@@ -3,6 +3,7 @@ import { useStore } from './store';
 import type { Macro, MacroType } from './store/macros';
 import { useToastStore } from './toastStore';
 import MacroInstructions from './MacroInstructions';
+import MidiMacroEditor from './MidiMacroEditor';
 
 export default function MacroBuilder() {
   const addMacro = useStore((s) => s.addMacro);
@@ -14,6 +15,7 @@ export default function MacroBuilder() {
   const [interval, setInterval] = useState(50);
   const [type, setType] = useState<MacroType>('keys');
   const [command, setCommand] = useState('');
+  const [midiData, setMidiData] = useState<number[][]>([]);
   const [nextId, setNextId] = useState('');
   const [tags, setTags] = useState('');
   const [showHelp, setShowHelp] = useState(false);
@@ -23,6 +25,7 @@ export default function MacroBuilder() {
     setCommand('');
     setType('keys');
     setInterval(50);
+    setMidiData([]);
     setNextId('');
     setTags('');
   };
@@ -46,6 +49,9 @@ export default function MacroBuilder() {
       if (keys.length === 0) return;
       macro.sequence = keys;
       macro.interval = Math.max(0, interval);
+    } else if (type === 'midi') {
+      if (midiData.length === 0) return;
+      macro.midiData = midiData;
     } else {
       if (!command.trim()) return;
       macro.command = command.trim();
@@ -95,6 +101,7 @@ export default function MacroBuilder() {
           <option value="shell">Shell</option>
           <option value="shell_win">Shell (Window)</option>
           <option value="shell_bg">Shell (Hidden)</option>
+          <option value="midi">MIDI</option>
         </select>
         {type === 'keys' ? (
           <>
@@ -113,6 +120,8 @@ export default function MacroBuilder() {
               onChange={(e) => setInterval(Math.max(0, Number(e.target.value)))}
             />
           </>
+        ) : type === 'midi' ? (
+          <MidiMacroEditor value={midiData} onChange={setMidiData} />
         ) : (
           <input
             className="form-control retro-input me-2 mb-1"
@@ -143,7 +152,11 @@ export default function MacroBuilder() {
           onClick={save}
           disabled={
             !name.trim() ||
-            (type === 'keys' ? !sequence.trim() : !command.trim())
+            (type === 'keys'
+              ? !sequence.trim()
+              : type === 'midi'
+                ? midiData.length === 0
+                : !command.trim())
           }
         >
           SAVE

--- a/src/MidiMacroEditor.tsx
+++ b/src/MidiMacroEditor.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useMidi } from './useMidi';
+
+interface Props {
+  value: number[][];
+  onChange: Dispatch<SetStateAction<number[][]>>;
+}
+
+export default function MidiMacroEditor({ value, onChange }: Props) {
+  const { listen } = useMidi();
+  const [recording, setRecording] = useState(false);
+
+  useEffect(() => {
+    if (!recording) return;
+    const unsubscribe = listen((msg) => {
+      if (msg.direction === 'in') {
+        onChange((prev) => [...prev, msg.message]);
+      }
+    });
+    return unsubscribe;
+  }, [recording, listen, onChange]);
+
+  const format = (bytes: number[]) =>
+    bytes.map((b) => b.toString(16).padStart(2, '0')).join(' ');
+
+  return (
+    <div className="midi-macro-editor">
+      <div className="mb-2">
+        <button
+          className="retro-button btn-sm me-2"
+          onClick={() => setRecording((r) => !r)}
+        >
+          {recording ? 'STOP' : 'REC'}
+        </button>
+        <button
+          className="retro-button btn-sm"
+          onClick={() => onChange([])}
+          disabled={value.length === 0}
+        >
+          CLEAR
+        </button>
+      </div>
+      <div className="midi-macro-list">
+        {value.length === 0 ? (
+          <div className="text-warning">NO MIDI DATA</div>
+        ) : (
+          value.map((msg, idx) => (
+            <div key={idx} className="text-monospace">
+              {format(msg)}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/macroMessages.ts
+++ b/src/macroMessages.ts
@@ -27,4 +27,8 @@ export const MACRO_MESSAGES: Record<MacroType, MacroMessage> = {
     type: 'keysType',
     payload: (m) => ({ sequence: m.sequence, interval: m.interval }),
   },
+  midi: {
+    type: 'send',
+    payload: () => ({ port: '', bytes: [] }),
+  },
 };

--- a/src/store/macros.ts
+++ b/src/store/macros.ts
@@ -1,7 +1,13 @@
 import { type StateCreator } from 'zustand';
 import type { StoreState } from './index';
 
-export type MacroType = 'keys' | 'app' | 'shell' | 'shell_win' | 'shell_bg';
+export type MacroType =
+  | 'keys'
+  | 'app'
+  | 'shell'
+  | 'shell_win'
+  | 'shell_bg'
+  | 'midi';
 
 export interface Macro {
   id: string;
@@ -10,6 +16,7 @@ export interface Macro {
   interval?: number;
   type?: MacroType;
   command?: string;
+  midiData?: number[][];
   nextId?: string;
   tags?: string[];
 }
@@ -29,8 +36,7 @@ export const createMacrosSlice: StateCreator<
   MacrosSlice
 > = (set) => ({
   macros: [],
-  addMacro: (macro) =>
-    set((state) => ({ macros: [...state.macros, macro] })),
+  addMacro: (macro) => set((state) => ({ macros: [...state.macros, macro] })),
   updateMacro: (macro) =>
     set((state) => ({
       macros: state.macros.map((m) => (m.id === macro.id ? macro : m)),
@@ -40,12 +46,7 @@ export const createMacrosSlice: StateCreator<
   reorderMacro: (from, to) =>
     set((state) => {
       const macros = [...state.macros];
-      if (
-        from < 0 ||
-        from >= macros.length ||
-        to < 0 ||
-        to >= macros.length
-      )
+      if (from < 0 || from >= macros.length || to < 0 || to >= macros.length)
         return { macros };
       const [m] = macros.splice(from, 1);
       macros.splice(to, 0, m);

--- a/src/useKeyMacroPlayer.ts
+++ b/src/useKeyMacroPlayer.ts
@@ -28,8 +28,17 @@ export function useKeyMacroPlayer() {
       }
       addToast(`Playing: ${macro.name}`, 'success');
       try {
-        const { type, payload } = MACRO_MESSAGES[macro.type || 'keys'];
-        sendSocketMessage({ type, ...payload(macro) });
+        if (macro.type === 'midi') {
+          const port = useStore.getState().devices.outputId;
+          if (port && macro.midiData) {
+            for (const bytes of macro.midiData) {
+              sendSocketMessage({ type: 'send', port, bytes });
+            }
+          }
+        } else {
+          const { type, payload } = MACRO_MESSAGES[macro.type || 'keys'];
+          sendSocketMessage({ type, ...payload(macro) });
+        }
         if (macro.nextId) {
           await playMacro(macro.nextId, visited);
         }


### PR DESCRIPTION
## Summary
- extend macro types with new `midi` option storing recorded byte sequences
- send MIDI data during macro playback and provide editor for capturing sequences
- allow creating and editing MIDI macros in the UI

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9f14242c8325a4511033fd6144a3