### PR TITLE
test: ensure runShell obeys rate limits

### DIFF
--- a/server/__tests__/websocketMidi.test.ts
+++ b/server/__tests__/websocketMidi.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import WebSocket from 'ws';
 import type { Server } from 'http';
-import type { SendMidiMessage } from '../../shared/messages';
+import type { SendMidiMessage, RunShellMessage } from '../../shared/messages';
 
 describe('WebSocket MIDI handling', () => {
   const API_KEY = 'test-key';
@@ -9,11 +9,20 @@ describe('WebSocket MIDI handling', () => {
   let stopServer: () => Promise<void>;
   let send: ReturnType<typeof vi.fn>;
   let exec: ReturnType<typeof vi.fn>;
+  let spawn: ReturnType<typeof vi.fn>;
+  let prevAllowed: string | undefined;
+  let prevRateLimit: string | undefined;
+  let prevRateInterval: string | undefined;
 
   beforeEach(async () => {
     vi.resetModules();
     process.env.API_KEY = API_KEY;
-    process.env.ALLOWED_CMDS = '';
+    prevAllowed = process.env.ALLOWED_CMDS;
+    process.env.ALLOWED_CMDS = 'echo';
+    prevRateLimit = process.env.CMD_RATE_LIMIT;
+    prevRateInterval = process.env.CMD_RATE_INTERVAL_MS;
+    process.env.CMD_RATE_LIMIT = '2';
+    process.env.CMD_RATE_INTERVAL_MS = '100';
     process.env.PORT = '0';
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -34,8 +43,15 @@ describe('WebSocket MIDI handling', () => {
       id === '1' ? output : undefined,
     );
 
-    exec = vi.fn();
-    vi.doMock('child_process', () => ({ exec }));
+    // Spy on child_process methods before requiring the server so they are used internally
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const cp = require('child_process');
+    exec = vi.spyOn(cp, 'exec').mockImplementation(() => undefined);
+    spawn = vi.spyOn(cp, 'spawn').mockImplementation(() => ({
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+    }));
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const mod = require('../dist/index.js');
@@ -46,6 +62,12 @@ describe('WebSocket MIDI handling', () => {
   afterEach(async () => {
     await stopServer();
     vi.clearAllMocks();
+    if (prevAllowed === undefined) delete process.env.ALLOWED_CMDS;
+    else process.env.ALLOWED_CMDS = prevAllowed;
+    if (prevRateLimit === undefined) delete process.env.CMD_RATE_LIMIT;
+    else process.env.CMD_RATE_LIMIT = prevRateLimit;
+    if (prevRateInterval === undefined) delete process.env.CMD_RATE_INTERVAL_MS;
+    else process.env.CMD_RATE_INTERVAL_MS = prevRateInterval;
   });
 
   it('ignores invalid midi messages', async () => {
@@ -76,5 +98,23 @@ describe('WebSocket MIDI handling', () => {
     ws.close();
     await new Promise((r) => ws.on('close', r));
     warn.mockRestore();
+  });
+
+  it('rate limits runShell commands', async () => {
+    const port = (server.address() as { port: number }).port;
+    const ws = new WebSocket(`ws://localhost:${port}?key=${API_KEY}`);
+    await new Promise((r) => ws.on('open', r));
+
+    const limit = Number(process.env.CMD_RATE_LIMIT);
+    const msg: RunShellMessage = { type: 'runShell', cmd: 'echo test' };
+    for (let i = 0; i < limit + 2; i++) {
+      ws.send(JSON.stringify(msg));
+    }
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(spawn).toHaveBeenCalledTimes(limit);
+
+    ws.close();
+    await new Promise((r) => ws.on('close', r));
   });
 });


### PR DESCRIPTION
## Summary
- add WebSocket test for runShell command rate limiting
- spy on child_process to track command execution and set small rate-limit window

## Testing
- `npm run format -- server/__tests__/websocketMidi.test.ts`
- `npm run lint -- server/__tests__/websocketMidi.test.ts`
- `npm run build`
- `npm test -- server/__tests__/websocketMidi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c30ff8beb88325ae8c4bab5354c99e